### PR TITLE
chore: Replaced inline tables and commands with `ComponentArchetype`

### DIFF
--- a/docs/docs/building-ui/archetypes/blank.md
+++ b/docs/docs/building-ui/archetypes/blank.md
@@ -9,63 +9,9 @@ The `blank` archetype is a foundational starter project for webforJ applications
 
 ## Using the `blank` archetype
 
-To create and scaffold a new `blank` project, follow these steps:
-
-1) **Navigate to the proper directory**:
-Open a terminal and move to the folder where you want to create your new project.
-
-2) **Run the `archetype:generate` command**:
-Use the Maven command below, and customize the `groupId`, `artifactId`, and `version` as needed for your project.
-
-<!-- vale off -->
-<Tabs>
-  <TabItem value="bash" label="Bash/Zsh" default>
-  ```bash
-  mvn -B archetype:generate \
-  -DarchetypeGroupId=com.webforj \
-  -DarchetypeArtifactId=webforj-archetype-blank \
-  -DgroupId=org.example \
-  -DarchetypeVersion=LATEST \
-  -DartifactId=my-app \
-  -Dversion=1.0-SNAPSHOT
-  ```
-  </TabItem>
-  <TabItem value="powershell" label="PowerShell">
-  ```powershell
-  mvn -B archetype:generate `
-  -DarchetypeGroupId="com.webforj" `
-  -DarchetypeArtifactId="webforj-archetype-blank" `
-  -DarchetypeVersion="LATEST" `
-  -DgroupId="org.example" `
-  -DartifactId="my-app" `
-  -Dversion="1.0-SNAPSHOT" 
-  ```
-  </TabItem>
-  <TabItem value="cmd" label="Command Prompt">
-  ```
-  mvn -B archetype:generate ^
-  -DarchetypeGroupId=com.webforj ^
-  -DarchetypeArtifactId=webforj-archetype-blank ^
-  -DgroupId=org.example ^
-  -DarchetypeVersion=LATEST ^
-  -DartifactId=my-app ^
-  -Dversion=1.0-SNAPSHOT
-  ```
-  </TabItem>
-</Tabs>
-<!-- vale on -->
-
-| Argument             | Explanation                                                                 |
-|----------------------|-----------------------------------------------------------------------------|
-| `archetypeGroupId` | The group ID of the archetype is `com.webforj` for webforJ archetypes.|
-| `archetypeArtifactId` | Specifies the name of the archetype to use. |
-| `archetypeVersion` | Specifies the version of the archetype to use. This ensures that the generated project is compatible with a specific archetype version. Using LATEST selects the most recent version available.|
-| `groupId`          | Represents the namespace for the generated project. Typically structured like a Java package, such as `org.example` and is used to uniquely identify your organization or project domain.|
-| `artifactId`       | Specifies the name of the generated project. This will be the name of the resulting artifact and the project folder.|
-| `version`          | Defines the version of the generated project. A common convention is MAJOR.MINOR-SNAPSHOT, like `1.0-SNAPSHOT`, where SNAPSHOT denotes that the project is still in development.|
-
-
-After running the command, Maven will generate the project files necessary to run the project.
+<ComponentArchetype
+project="blank"
+/>
 
 ### Run the app
 

--- a/docs/docs/building-ui/archetypes/hello-world.md
+++ b/docs/docs/building-ui/archetypes/hello-world.md
@@ -15,62 +15,9 @@ This archetype creates a minimalistic app with a few components and some styling
 
 ## Using the `hello-world` archetype
 
-To create and scaffold a new `hello-world` project, follow these steps:
-
-1) **Navigate to the proper directory**:
-Open a terminal and move to the folder where you want to create your new project.
-
-2) **Run the `archetype:generate` command**:
-Use the Maven command below, and customize the `groupId`, `artifactId`, and `version` as needed for your project.
-
-<!-- vale off -->
-<Tabs>
-  <TabItem value="bash" label="Bash/Zsh" default>
-  ```bash
-  mvn -B archetype:generate \
-  -DarchetypeGroupId=com.webforj \
-  -DarchetypeArtifactId=webforj-archetype-hello-world \
-  -DgroupId=org.example \
-  -DarchetypeVersion=LATEST \
-  -DartifactId=my-app \
-  -Dversion=1.0-SNAPSHOT
-  ```
-  </TabItem>
-  <TabItem value="powershell" label="PowerShell">
-  ```powershell
-  mvn -B archetype:generate `
-  -DarchetypeGroupId="com.webforj" `
-  -DarchetypeArtifactId="webforj-archetype-hello-world" `
-  -DarchetypeVersion="LATEST" `
-  -DgroupId="org.example" `
-  -DartifactId="my-app" `
-  -Dversion="1.0-SNAPSHOT" 
-  ```
-  </TabItem>
-  <TabItem value="cmd" label="Command Prompt">
-  ```
-  mvn -B archetype:generate ^
-  -DarchetypeGroupId=com.webforj ^
-  -DarchetypeArtifactId=webforj-archetype-hello-world ^
-  -DgroupId=org.example ^
-  -DarchetypeVersion=LATEST ^
-  -DartifactId=my-app ^
-  -Dversion=1.0-SNAPSHOT
-  ```
-  </TabItem>
-</Tabs>
-<!-- vale on -->
-
-| Argument             | Explanation                                                                 |
-|----------------------|-----------------------------------------------------------------------------|
-| `archetypeGroupId` | The group ID of the archetype is `com.webforj` for webforJ archetypes.|
-| `archetypeArtifactId` | Specifies the name of the archetype to use. |
-| `archetypeVersion` | Specifies the version of the archetype to use. This ensures that the generated project is compatible with a specific archetype version. Using LATEST selects the most recent version available.|
-| `groupId`          | Represents the namespace for the generated project. Typically structured like a Java package, such as `org.example` and is used to uniquely identify your organization or project domain.|
-| `artifactId`       | Specifies the name of the generated project. This will be the name of the resulting artifact and the project folder.|
-| `version`          | Defines the version of the generated project. A common convention is MAJOR.MINOR-SNAPSHOT, like `1.0-SNAPSHOT`, where SNAPSHOT denotes that the project is still in development.|
-
-After running the command, Maven will generate the project files necessary to run the project.
+<ComponentArchetype
+project="hello-world"
+/>
 
 ### Run the app
 

--- a/docs/docs/building-ui/archetypes/sidemenu.md
+++ b/docs/docs/building-ui/archetypes/sidemenu.md
@@ -10,62 +10,9 @@ For projects that need a structured navigation system, the `sidemenu` archetype 
 
 ## Using the `sidemenu` archetype
 
-To create and scaffold a new `sidemenu` project, follow these steps:
-
-1) **Navigate to the proper directory**:
-Open a terminal and move to the folder where you want to create your new project.
-
-2) **Run the `archetype:generate` command**:
-Use the Maven command below, and customize the `groupId`, `artifactId`, and `version` as needed for your project.
-
-<!-- vale off -->
-<Tabs>
-  <TabItem value="bash" label="Bash/Zsh" default>
-  ```bash
-  mvn -B archetype:generate \
-  -DarchetypeGroupId=com.webforj \
-  -DarchetypeArtifactId=webforj-archetype-sidemenu \
-  -DgroupId=org.example \
-  -DarchetypeVersion=LATEST \
-  -DartifactId=my-app \
-  -Dversion=1.0-SNAPSHOT
-  ```
-  </TabItem>
-  <TabItem value="powershell" label="PowerShell">
-  ```powershell
-  mvn -B archetype:generate `
-  -DarchetypeGroupId="com.webforj" `
-  -DarchetypeArtifactId="webforj-archetype-sidemenu" `
-  -DarchetypeVersion="LATEST" `
-  -DgroupId="org.example" `
-  -DartifactId="my-app" `
-  -Dversion="1.0-SNAPSHOT" 
-  ```
-  </TabItem>
-  <TabItem value="cmd" label="Command Prompt">
-  ```
-  mvn -B archetype:generate ^
-  -DarchetypeGroupId=com.webforj ^
-  -DarchetypeArtifactId=webforj-archetype-sidemenu ^
-  -DgroupId=org.example ^
-  -DarchetypeVersion=LATEST ^
-  -DartifactId=my-app ^
-  -Dversion=1.0-SNAPSHOT
-  ```
-  </TabItem>
-</Tabs>
-<!-- vale on -->
-
-| Argument             | Explanation                                                                 |
-|----------------------|-----------------------------------------------------------------------------|
-| `archetypeGroupId` | The group ID of the archetype is `com.webforj` for webforJ archetypes.|
-| `archetypeArtifactId` | Specifies the name of the archetype to use. |
-| `archetypeVersion` | Specifies the version of the archetype to use. This ensures that the generated project is compatible with a specific archetype version. Using LATEST selects the most recent version available.|
-| `groupId`          | Represents the namespace for the generated project. Typically structured like a Java package, such as `org.example` and is used to uniquely identify your organization or project domain.|
-| `artifactId`       | Specifies the name of the generated project. This will be the name of the resulting artifact and the project folder.|
-| `version`          | Defines the version of the generated project. A common convention is MAJOR.MINOR-SNAPSHOT, like `1.0-SNAPSHOT`, where SNAPSHOT denotes that the project is still in development.|
-
-After running the command, Maven will generate the project files necessary to run the project.
+<ComponentArchetype
+project="sidemenu"
+/>
 
 ### Run the app
 

--- a/docs/docs/building-ui/archetypes/tabs.md
+++ b/docs/docs/building-ui/archetypes/tabs.md
@@ -9,62 +9,9 @@ The `tabs` starting project generates an app with a simple tabbed interface. Ide
 
 ## Using the `tabs` archetype
 
-To create and scaffold a new `tabs` project, follow these steps:
-
-1) **Navigate to the proper directory**:
-Open a terminal and move to the folder where you want to create your new project.
-
-2) **Run the `archetype:generate` command**:
-Use the Maven command below, and customize the `groupId`, `artifactId`, and `version` as needed for your project.
-
-<!-- vale off -->
-<Tabs>
-  <TabItem value="bash" label="Bash/Zsh" default>
-  ```bash
-  mvn -B archetype:generate \
-  -DarchetypeGroupId=com.webforj \
-  -DarchetypeArtifactId=webforj-archetype-tabs \
-  -DgroupId=org.example \
-  -DarchetypeVersion=LATEST \
-  -DartifactId=my-app \
-  -Dversion=1.0-SNAPSHOT
-  ```
-  </TabItem>
-  <TabItem value="powershell" label="PowerShell">
-  ```powershell
-  mvn -B archetype:generate `
-  -DarchetypeGroupId="com.webforj" `
-  -DarchetypeArtifactId="webforj-archetype-tabs" `
-  -DarchetypeVersion="LATEST" `
-  -DgroupId="org.example" `
-  -DartifactId="my-app" `
-  -Dversion="1.0-SNAPSHOT" 
-  ```
-  </TabItem>
-  <TabItem value="cmd" label="Command Prompt">
-  ```
-  mvn -B archetype:generate ^
-  -DarchetypeGroupId=com.webforj ^
-  -DarchetypeArtifactId=webforj-archetype-tabs ^
-  -DgroupId=org.example ^
-  -DarchetypeVersion=LATEST ^
-  -DartifactId=my-app ^
-  -Dversion=1.0-SNAPSHOT
-  ```
-  </TabItem>
-</Tabs>
-<!-- vale on -->
-
-| Argument             | Explanation                                                                 |
-|----------------------|-----------------------------------------------------------------------------|
-| `archetypeGroupId` | The group ID of the archetype is `com.webforj` for webforJ archetypes.|
-| `archetypeArtifactId` | Specifies the name of the archetype to use. |
-| `archetypeVersion` | Specifies the version of the archetype to use. This ensures that the generated project is compatible with a specific archetype version. Using LATEST selects the most recent version available.|
-| `groupId`          | Represents the namespace for the generated project. Typically structured like a Java package, such as `org.example` and is used to uniquely identify your organization or project domain.|
-| `artifactId`       | Specifies the name of the generated project. This will be the name of the resulting artifact and the project folder.|
-| `version`          | Defines the version of the generated project. A common convention is MAJOR.MINOR-SNAPSHOT, like `1.0-SNAPSHOT`, where SNAPSHOT denotes that the project is still in development.|
-
-After running the command, Maven will generate the project files necessary to run the project.
+<ComponentArchetype
+project="tabs"
+/>
 
 ### Run the app
 

--- a/docs/docs/configuration/bbj-installation/docker.md
+++ b/docs/docs/configuration/bbj-installation/docker.md
@@ -145,24 +145,10 @@ in the previous step.
 
 
 ### Using the starter project
-To create and scaffold a new project, follow these steps:
 
-1) **Navigate to the proper directory**:
-Open a terminal and move to the folder where you want to create your new project.
-
-2) **Run the archetype command**:
-Use the Maven command below, and customize the `groupId`, `artifactId`, and `version` as needed for your project. To proceed with the webforJ starter project, use the following command:
-
-```bash
-mvn -B archetype:generate \
--DarchetypeGroupId=com.webforj \
--DarchetypeArtifactId=webforj-archetype-bbj-hello-world \
--DgroupId=org.example \
--DartifactId=my-hello-world-app \
--Dversion=1.0-SNAPSHOT
-```
-
-After running the command, Maven will generate the project files necessary to run the starter project.
+<ComponentArchetype
+project="hello-world"
+/>
 
 ### Launching the app
 

--- a/docs/docs/configuration/bbj-installation/local.md
+++ b/docs/docs/configuration/bbj-installation/local.md
@@ -134,24 +134,9 @@ Finally, click on the "Configure" button, which will open a new window. In this 
 ## 4. Using the starter project
 Once BBj and the required webforJ plugin are installed and configured, you can create a new, scaffolded project from the command line. This project comes with the necessary tools to run your first webforJ program.
 
-To create and scaffold a new project, follow these steps:
-
-1) **Navigate to the proper directory**:
-Open a terminal and move to the folder where you want to create your new project.
-
-2) **Run the archetype command**:
-Use the Maven command below, and customize the `groupId`, `artifactId`, and `version` as needed for your project. To proceed with the webforJ starter project, use the following command:
-
-```bash
-mvn -B archetype:generate \
--DarchetypeGroupId=com.webforj \
--DarchetypeArtifactId=webforj-archetype-bbj-hello-world \
--DgroupId=org.example \
--DartifactId=my-hello-world-app \
--Dversion=1.0-SNAPSHOT
-```
-
-After running the command, Maven will generate the project files necessary to run the starter project.
+<ComponentArchetype
+project="hello-world"
+/>
 
 ## 5. Launching the app
 

--- a/docs/docs/introduction/getting-started.md
+++ b/docs/docs/introduction/getting-started.md
@@ -17,64 +17,9 @@ import DocCardList from '@theme/DocCardList';
 
 ## Using the `hello-world` archetype
 
-To create and scaffold a new `hello-world` project, follow these steps:
-
-1) **Navigate to the proper directory**:
-Open a terminal and move to the folder where you want to create your new project.
-
-2) **Run the `archetype:generate` command**:
-Use the Maven command below, and customize the `groupId`, `artifactId`, and `version` as needed for your project.
-
-<!-- vale off -->
-<Tabs>
-  <TabItem value="bash" label="Bash/Zsh" default>
-  ```bash
-  mvn -B archetype:generate \
-  -DarchetypeGroupId=com.webforj \
-  -DarchetypeArtifactId=webforj-archetype-hello-world \
-  -DgroupId=org.example \
-  -DarchetypeVersion=LATEST \
-  -DartifactId=my-hello-world-app \
-  -Dversion=1.0-SNAPSHOT
-  ```
-  </TabItem>
-  <TabItem value="powershell" label="PowerShell">
-  ```powershell
-  mvn -B archetype:generate `
-  -DarchetypeGroupId="com.webforj" `
-  -DarchetypeArtifactId="webforj-archetype-hello-world" `
-  -DarchetypeVersion="LATEST" `
-  -DgroupId="org.example" `
-  -DartifactId="my-hello-world-app" `
-  -Dversion="1.0-SNAPSHOT" 
-  ```
-  </TabItem>
-  <TabItem value="cmd" label="Command Prompt">
-  ```
-  mvn -B archetype:generate ^
-  -DarchetypeGroupId=com.webforj ^
-  -DarchetypeArtifactId=webforj-archetype-hello-world ^
-  -DgroupId=org.example ^
-  -DarchetypeVersion=LATEST ^
-  -DartifactId=my-hello-world-app ^
-  -Dversion=1.0-SNAPSHOT
-  ```
-  </TabItem>
-</Tabs>
-<!-- vale on -->
-
-| Argument             | Explanation                                                                 |
-|----------------------|-----------------------------------------------------------------------------|
-| `archetypeGroupId` | The group ID of the archetype is `com.webforj` for webforJ archetypes.|
-| `archetypeArtifactId` | Specifies the name of the archetype to use. |
-| `archetypeVersion` | Specifies the version of the archetype to use. This ensures that the generated project is compatible with a specific archetype version. Using LATEST selects the most recent version available.|
-| `groupId`          | Represents the namespace for the generated project. Typically structured like a Java package, such as `org.example` and is used to uniquely identify your organization or project domain.|
-| `artifactId`       | Specifies the name of the generated project. This will be the name of the resulting artifact and the project folder.|
-| `version`          | Defines the version of the generated project. A common convention is MAJOR.MINOR-SNAPSHOT, like `1.0-SNAPSHOT`, where SNAPSHOT denotes that the project is still in development.|
-
-
-After running the command, Maven will generate the project files necessary to run the project.
-
+<ComponentArchetype
+project="hello-world"
+/>
 
 :::tip
 webforJ comes with several predefined archetypes that help you quickly start your webforJ development. To see a complete list of available archetypes, please refer to the [archetypes catalog](../building-ui/archetypes/overview).

--- a/docs/src/components/DocsTools/ComponentArchetype.js
+++ b/docs/src/components/DocsTools/ComponentArchetype.js
@@ -1,0 +1,94 @@
+/** @jsxImportSource @emotion/react */
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from "@theme/CodeBlock";
+
+export default function ComponentArchetype({project}){
+  return(<>
+  <p>To create and scaffold a new <code>{project}</code> project, follow these steps:
+  </p>
+  <ol>
+    <li><strong>Navigate to the proper directory</strong>: Open a terminal and move to the folder where you want to create your new project.
+    </li>
+    <li><strong>Run the <code>archetype:generate</code> command</strong>: Use the Maven command below, and customize the <code>groupId</code>, <code>artifactId</code>, and <code>version</code> as needed for your project.
+    </li>
+  </ol>
+  <Tabs>
+    <TabItem value="bash" label="Bash/Zsh" default>
+      <CodeBlock language="bash">
+{`mvn -B archetype:generate \\
+-DarchetypeGroupId=com.webforj \\
+-DarchetypeArtifactId=webforj-archetype-${project} \\
+-DarchetypeVersion=LATEST \\
+-DgroupId=org.example \\
+-DartifactId=my-app \\
+-Dversion=1.0-SNAPSHOT \\
+-DappName=MyApp`}
+      </CodeBlock>
+    </TabItem>
+    <TabItem value="powershell" label="PowerShell">
+      <CodeBlock language="powershell">
+{`mvn -B archetype:generate \`
+-DarchetypeGroupId="com.webforj" \`
+-DarchetypeArtifactId="webforj-archetype-${project}" \`
+-DarchetypeVersion="LATEST" \`
+-DgroupId="org.example" \`
+-DartifactId="my-app" \`
+-Dversion="1.0-SNAPSHOT" \`
+-DappName="MyApp"`}
+      </CodeBlock>
+    </TabItem>
+    <TabItem value="cmd" label="Command Prompt">
+      <CodeBlock>
+{`mvn -B archetype:generate ^
+-DarchetypeGroupId="com.webforj" ^
+-DarchetypeArtifactId="webforj-archetype-${project}" ^
+-DarchetypeVersion="LATEST" ^
+-DgroupId="org.example" ^
+-DartifactId="my-app" ^
+-Dversion="1.0-SNAPSHOT" ^
+-DappName="MyApp"`}
+      </CodeBlock>
+    </TabItem>
+  </Tabs>
+  <table>
+    <thead>
+      <th>Argument</th>
+      <th>Explanation</th>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>archetypeGroupId</code></td>
+        <td>The group ID of the archetype is <code>com.webforj</code> for webforJ archetypes.</td>
+      </tr>
+      <tr>
+        <td><code>archetypeArtifactId</code></td>
+        <td>Specifies the name of the archetype to use.</td>
+      </tr>
+      <tr>
+        <td><code>archetypeVersion</code></td>
+        <td>Specifies the version of the archetype to use. This ensures that the generated project is compatible with a specific archetype version. Using LATEST selects the most recent version available.</td>
+      </tr>
+      <tr>
+        <td><code>groupId</code></td>
+        <td>Represents the namespace for the generated project. Typically structured like a Java package, such as <code>org.example</code> and is used to uniquely identify your organization or project domain.</td>
+      </tr>
+      <tr>
+        <td><code>artifactId</code></td>
+        <td>Specifies the name of the generated project. This will be the name of the resulting artifact and the project folder.</td>
+      </tr>
+      <tr>
+        <td><code>version</code></td>
+        <td>Defines the version of the generated project. A common convention is MAJOR.MINOR-SNAPSHOT, like <code>1.0-SNAPSHOT</code>, where SNAPSHOT denotes that the project is still in development.</td>
+      </tr>
+      <tr>
+        <td><code>appName</code></td>
+        <td>An optional parameter that can be used in the generated project's POM file. Depending on the used webforJ archetype, it can be utilized as a default title for the application. </td>
+      </tr>
+    </tbody>
+  </table>
+<p>After running the command, Maven will generate the project files necessary to run the project.
+</p>
+</>);
+}

--- a/docs/src/theme/MDXComponents.js
+++ b/docs/src/theme/MDXComponents.js
@@ -11,6 +11,7 @@ import JavadocLink from '@site/src/components/DocsTools/JavadocLink';
 import ParentLink from '@site/src/components/DocsTools/ParentLink';
 import TableBuilder from '@site/src/components/DocsTools/TableBuilder';
 import TabSwitcher from '@site/src/components/DocsTools/TabSwitcher';
+import ComponentArchetype from '@site/src/components/DocsTools/ComponentArchetype';
 import DocCardList from '@theme/DocCardList';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -29,6 +30,7 @@ export default {
   ParentLink,
   TableBuilder,
   TabSwitcher,
+  ComponentArchetype,
   Tabs,
   TabItem,
 };


### PR DESCRIPTION
This PR closes Issue #1 and Issue #2 by replacing repeated inline content with `ComponentArchetype`. This component uses an attribute called `project` to generate the code snippets for the `archetype:generate` command and a table explaining each of the arguments, including the optional `appName`.

This PR reflects the changes that were made in [webforj-docs PR #427](https://github.com/webforj/webforj-docs/pull/427)