### PR TITLE
refactor: Increased the documented duration of the Toast Component from 3000ms to 5000ms

### DIFF
--- a/docs/docs/components/toast.md
+++ b/docs/docs/components/toast.md
@@ -46,15 +46,15 @@ Toasts are versatile and provide subtle notifications for real-time feedback. Fo
 
 ## Duration
 
-You can configure `Toast` notifications to disappear after a set duration or persist on the screen until they're dismissed, depending on your needs. By default, a `Toast` closes automatically after 3000 milliseconds. You can customize the duration with the `setDuration()` method, or simply supply a duration parameter to the constructor or the `show()` method.
+You can configure `Toast` notifications to disappear after a set duration or persist on the screen until they're dismissed, depending on your needs. You can customize the duration with the `setDuration()` method, or simply supply a duration parameter to the constructor or the `show()` method.
 
 :::info Default Duration
-By default, the `Toast` will have a duration of 3000 milliseconds.
+By default, a `Toast` closes automatically after 5000 milliseconds.
 :::
 
 ```java
 Toast toast = new Toast("Sample Notification");
-toast.setDuration(5000);
+toast.setDuration(10000);
 toast.open();
 ```
 


### PR DESCRIPTION
This PR will close Issue #3.

**Additional Changes**
- Removed a sentence in Duration section that was identical to the following info admonition
- Increased the time duration in the code snippet to no longer be the default (5000ms → 10000ms)