### PR TITLE
config: Adjust Vale settings to ignore semicolons, parentheses, and Latin

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -5,9 +5,11 @@ Packages = Google
 
 [*.{md,txt}]
 BasedOnStyles = Google
-; Google.Semicolons = NO
+Google.Semicolons = NO
 Google.Passive = NO
 Google.Will = NO
+Google.Parens = NO
+Google.Latin = NO
 
 [formats]
 mdx = md


### PR DESCRIPTION
This PR suppresses warning messages for semicolons, parentheses, and the use of Latin.
This PR reflects the changes that were made in [webforj-docs PR#279](https://github.com/webforj/webforj-docs/pull/279).
