### PR TITLE
chore: Adjusted dimensions for `ChoiceBox` options

### DIFF
--- a/src/main/java/com/webforj/samples/views/flexlayout/item/FlexOrderView.java
+++ b/src/main/java/com/webforj/samples/views/flexlayout/item/FlexOrderView.java
@@ -41,11 +41,11 @@ public class FlexOrderView extends Composite<Div> {
 
     MaskedNumberField order = new MaskedNumberField("5")
         .setLabel("Order:")
-        .setWidth("200px");
+        .setWidth("100px");
     Button submit = new Button("Set Order");
     order.setInvalidMessage("Order can not be empty.");
     order.setNegateable(false);
-    submit.setHeight("34px")
+    submit.setSize("100px","34px")
         .onClick(e -> {
           if (order.getText().isEmpty()) {
             order.setInvalid(true);

--- a/src/main/resources/css/flexlayout/container/flexContainerBuilder.css
+++ b/src/main/resources/css/flexlayout/container/flexContainerBuilder.css
@@ -34,6 +34,7 @@ dwc-button {
 
 .flex__options {
   padding: 20px 20px 0 20px;
+  width: 175px;
 }
 
 .code__block {


### PR DESCRIPTION
This PR will close Issue #136 by widening the width of the `ChoiceBox` and to automatically display every item without scrolling.