### PR TITLE
chore: Corrected the returned `MessageDialog` in `TableColumnPinningView`

### DIFF
--- a/src/main/java/com/webforj/samples/views/table/TableColumnPinningView.java
+++ b/src/main/java/com/webforj/samples/views/table/TableColumnPinningView.java
@@ -31,7 +31,7 @@ public class TableColumnPinningView extends Composite<Div> {
     }).setAlignment(Column.Alignment.RIGHT);
 
     ButtonRenderer<MusicRecord> editRenderer = new ButtonRenderer<>("Edit", e -> {
-      showMessageDialog("You asked to edit the record" + 0 + "Edit Record");
+      showMessageDialog("You asked to edit record number <b>" + e.getItem().getNumber() + "</b>.","Edit Record");
     });
     table.addColumn(editRenderer).setAlignment(Column.Alignment.CENTER)
         .setPinDirection(Column.PinDirection.RIGHT);


### PR DESCRIPTION
This PR closes Issue #111.

The message returned will now included the record numbered clicked and formatted like the following:
![Screenshot 2025-03-04 150329](https://github.com/user-attachments/assets/d686bfbf-84a5-4ee7-857a-8feb30673633)