### PR TITLE
feat: Added detection to run app layout demos in both dev mode and on jetty server

### DIFF
--- a/docs/src/components/DocsTools/AppLayoutViewer.js
+++ b/docs/src/components/DocsTools/AppLayoutViewer.js
@@ -3,7 +3,8 @@
 import { React, useState} from 'react'
 import { jsx, css } from '@emotion/react';
 import { useColorMode } from '@docusaurus/theme-common';
-import ComponentDemo, {OpenNewWindowButton} from './ComponentDemo';
+import ComponentDemo, {OpenNewWindowButton, isLocalhost} from './ComponentDemo';
+import GLOBALS from "../../../siteConfig";
 
 export default function AppLayoutViewer({path, mobile, javaE, cssURL}) {
     
@@ -52,9 +53,9 @@ export default function AppLayoutViewer({path, mobile, javaE, cssURL}) {
           onMouseEnter={() => setButtonVisible(true)}
           onMouseLeave={() => setButtonVisible(false)}>
         <div css={fadeInButton}>
-                {OpenNewWindowButton({ url: path })}
+                {OpenNewWindowButton({ url: (isLocalhost ? GLOBALS.IFRAME_SRC_DEV : GLOBALS.IFRAME_SRC_LIVE) + path })}
         </div>
-            <iframe src={path+"&__theme__="+ (useColorMode().colorMode)} css={demoContent} loading='lazy'>
+            <iframe src={(isLocalhost ? GLOBALS.IFRAME_SRC_DEV : GLOBALS.IFRAME_SRC_LIVE) + path + "&__theme__=" + (useColorMode().colorMode)} css={demoContent} loading='lazy'>
             </iframe>
         </div>
         <br/>

--- a/docs/src/components/DocsTools/ComponentDemo.js
+++ b/docs/src/components/DocsTools/ComponentDemo.js
@@ -108,6 +108,10 @@ export function OpenNewWindowButton({ url }) {
   );
 }
 
+export const isLocalhost = typeof window !== "undefined" &&
+window.location.hostname === "localhost" &&
+window.location.port === "3000";
+
 export default function ComponentDemo({
   path,
   javaC,
@@ -152,9 +156,6 @@ export default function ComponentDemo({
   const iframeRef = useRef(null);
   const codeButtonRef = useRef(null);
 
-  const isLocalhost = typeof window !== "undefined" &&
-  window.location.hostname === "localhost" &&
-  window.location.port === "3000";
   useEffect(() => {
     if (javaE) {
       fetch(javaE)


### PR DESCRIPTION
This PR will close Issue #181.

I moved the `isLocalhost` const so it could also be used as an import for `AppLayoutViewer.js`.