### PR TITLE
chore: Update UrlRewriteFilter to 5.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.tuckey</groupId>
       <artifactId>urlrewritefilter</artifactId>
-      <version>4.0.4</version>
+      <version>5.1.3</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
This PR will close Issue #197.

Jakarta EE 9 renamed all the `javax.*` packages to `jakarta.*`. Based on the [UrlRewriteFilter Changelog](https://tuckey.org/urlrewrite/manual/5.1/introduction.html#changelog), the change to be fully based on jakarta servlet API 5 happened in version 5.1.1.

For simplicity, I used the latest version, 5.1.3, as listed here: https://mvnrepository.com/artifact/org.tuckey/urlrewritefilter