### PR TITLE
chore: Improved WebforjBBjBridge examples in 25.00 Upgrade Guide

### DIFF
--- a/docs/docs/upgrading/webforj-25.00.md
+++ b/docs/docs/upgrading/webforj-25.00.md
@@ -140,16 +140,22 @@ Previous versions of webforJ uses strings and integers directly for the `Webforj
 
 **Before**
 ```java
-WebforjBBjBridge.msgbox("Are you sure you want to delete this file?", 2, "Deletion")
+Environment environment = Environment.getCurrent();
+WebforjBBjBridge bridge = environment.getWebforjHelper();
+
+bridge.msgbox("Are you sure you want to delete this file?", 2, "Deletion");
 ```
 
 **After**
 ```java
+Environment environment = Environment.getCurrent();
+WebforjBBjBridge bridge = environment.getBridge();
+
 dialog = new ConfirmDialog(
       "Are you sure you want to delete this file?", "Deletion",
       ConfirmDialog.OptionType.OK_CANCEL, ConfirmDialog.MessageType.QUESTION);
 
-WebforjBBjBridge.msgbox(dialog)
+bridge.msgbox(dialog);
 ```
 
 <!-- ## Environment.logError removed -->

--- a/docs/docs/upgrading/webforj-25.00.md
+++ b/docs/docs/upgrading/webforj-25.00.md
@@ -140,22 +140,16 @@ Previous versions of webforJ uses strings and integers directly for the `Webforj
 
 **Before**
 ```java
-Environment environment = Environment.getCurrent();
-WebforjBBjBridge bridge = environment.getWebforjHelper();
-
-bridge.msgbox("Are you sure you want to delete this file?", 2, "Deletion");
+App.msgbox("Are you sure you want to delete this file?", 2, "Deletion");
 ```
 
 **After**
 ```java
-Environment environment = Environment.getCurrent();
-WebforjBBjBridge bridge = environment.getBridge();
-
 dialog = new ConfirmDialog(
       "Are you sure you want to delete this file?", "Deletion",
       ConfirmDialog.OptionType.OK_CANCEL, ConfirmDialog.MessageType.QUESTION);
 
-bridge.msgbox(dialog);
+dialog.show();
 ```
 
 <!-- ## Environment.logError removed -->


### PR DESCRIPTION
For [this section](https://docs.webforj.com/docs/upgrading/webforj-25.00#using-the-confirmdialog-component-for-the-msgbox-method) of the upgrade guide:
- Added semicolons where needed
- rewrote examples to use an instance of `WebforjBBjBridge` with both the deprecated and currrent methods