### PR TITLE
chore: Corrected before and after examples for `WebforjBBjBridge.msgbox()`

### DIFF
--- a/docs/docs/upgrading/webforj-25.00.md
+++ b/docs/docs/upgrading/webforj-25.00.md
@@ -140,16 +140,22 @@ Previous versions of webforJ uses strings and integers directly for the `Webforj
 
 **Before**
 ```java
-App.msgbox("Are you sure you want to delete this file?", 2, "Deletion");
+Environment environment = Environment.getCurrent();
+WebforjBBjBridge bridge = environment.getWebforjHelper();
+
+int msgboxResult = bridge.msgbox("Are you sure you want to delete this file?", 1, "Deletion");
 ```
 
 **After**
 ```java
-dialog = new ConfirmDialog(
+Environment environment = Environment.getCurrent();
+WebforjBBjBridge bridge = environment.getBridge();
+
+ConfirmDialog dialog = new ConfirmDialog(
       "Are you sure you want to delete this file?", "Deletion",
       ConfirmDialog.OptionType.OK_CANCEL, ConfirmDialog.MessageType.QUESTION);
 
-dialog.show();
+int msgboxResult = bridge.msgbox(dialog);
 ```
 
 <!-- ## Environment.logError removed -->


### PR DESCRIPTION
The following Java snippets are the for the [WebforjBBjBridge changes](https://docs.webforj.com/docs/upgrading/webforj-25.00#webforjbbjbridge-changes) section. It currently uses an instance of the `App` class, but this PR corrects it to use the `WebforjBBjBridge` class, and shows the before and after methods for getting an instance of the class.