### PR TITLE
feat: add client component docs for dwc-app-nav and dwc-app-nav-item

### DIFF
--- a/docs/docs/client-components/app-nav-item.md
+++ b/docs/docs/client-components/app-nav-item.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 0
+title: <dwc-app-nav-item>
+sidebar_class_name: sidebar--item__hidden
+slug: app-nav-item
+description: A user guide article for the app-nav-item
+// pagination_prev: null
+// pagination_next: null
+---
+<DocChip chip='shadow' />
+
+:::info CLIENT COMPONENT
+This section outlines styling information for the **`<dwc-app-nav-item>`** component. This component is **client side only** - it can't be instantiated on its own via the API, but may make up part of API components.
+:::
+
+### Shadow parts
+
+  These are the various parts of the shadow DOM for the component, which will be required when styling via CSS is desired.
+  
+  <TableBuilder tag='dwc-app-nav-item' table="parts"/>
+
+### Reflected attributes
+
+  The reflected attributes of a component will be shown as attributes in the rendered HTML element for the component in the DOM. This means that styling can be applied using these attributes.
+  
+  <TableBuilder tag='dwc-app-nav-item' table="reflects"/>
+
+### Dependencies
+
+  This component relies on the following components - see the related article for more detailed styling information:
+  
+  <TableBuilder tag='dwc-app-nav-item' table="dependencies"/>

--- a/docs/docs/client-components/app-nav-item.md
+++ b/docs/docs/client-components/app-nav-item.md
@@ -7,17 +7,20 @@ description: A user guide article for the app-nav-item
 // pagination_prev: null
 // pagination_next: null
 ---
+
 <DocChip chip='shadow' />
+
+<br />
 
 :::info CLIENT COMPONENT
 This section outlines styling information for the **`<dwc-app-nav-item>`** component. This component is **client side only** - it can't be instantiated on its own via the API, but may make up part of API components.
 :::
 
 ### Shadow parts
+These are the various parts of the shadow DOM for the component, which will be required when styling via CSS is desired.
+<TableBuilder tag='dwc-app-nav-item' table="parts"/>
 
-  These are the various parts of the shadow DOM for the component, which will be required when styling via CSS is desired.
-  
-  <TableBuilder tag='dwc-app-nav-item' table="parts"/>
+
 
 ### Reflected attributes
 

--- a/docs/docs/client-components/app-nav.md
+++ b/docs/docs/client-components/app-nav.md
@@ -7,20 +7,23 @@ description: A user guide article for the app-nav
 // pagination_prev: null
 // pagination_next: null
 ---
+
 <DocChip chip='shadow' />
+
+<br />
 
 :::info CLIENT COMPONENT
 This section outlines styling information for the **`<dwc-app-nav>`** component. This component is **client side only** - it can't be instantiated on its own via the API, but may make up part of API components.
 :::
 
-### Shadow parts
 
-  These are the various parts of the shadow DOM for the component, which will be required when styling via CSS is desired.
-  
-  <TableBuilder tag='dwc-app-nav' table="parts"/>
+
+
 
 ### Reflected attributes
 
   The reflected attributes of a component will be shown as attributes in the rendered HTML element for the component in the DOM. This means that styling can be applied using these attributes.
   
   <TableBuilder tag='dwc-app-nav' table="reflects"/>
+
+

--- a/docs/docs/client-components/app-nav.md
+++ b/docs/docs/client-components/app-nav.md
@@ -1,0 +1,26 @@
+---
+sidebar_position: 0
+title: <dwc-app-nav>
+sidebar_class_name: sidebar--item__hidden
+slug: app-nav
+description: A user guide article for the app-nav
+// pagination_prev: null
+// pagination_next: null
+---
+<DocChip chip='shadow' />
+
+:::info CLIENT COMPONENT
+This section outlines styling information for the **`<dwc-app-nav>`** component. This component is **client side only** - it can't be instantiated on its own via the API, but may make up part of API components.
+:::
+
+### Shadow parts
+
+  These are the various parts of the shadow DOM for the component, which will be required when styling via CSS is desired.
+  
+  <TableBuilder tag='dwc-app-nav' table="parts"/>
+
+### Reflected attributes
+
+  The reflected attributes of a component will be shown as attributes in the rendered HTML element for the component in the DOM. This means that styling can be applied using these attributes.
+  
+  <TableBuilder tag='dwc-app-nav' table="reflects"/>

--- a/docs/docs/components/_dwc_control_map.json
+++ b/docs/docs/components/_dwc_control_map.json
@@ -42,5 +42,6 @@
 "Alert": "dwc-alert",
 "Toolbar": "dwc-toolbar",
 "AppNavItem": "dwc-app-nav-item",
-"Terminal": "dwc-terminal"
+"Terminal": "dwc-terminal",
+"AppNav": "dwc-app-nav"
 }


### PR DESCRIPTION
This PR will close Issue #309.

@MatthewHawkins This PR is a draft because the `<dwc-app-nav>` client component does not contain reflected attributes, shadow parts, CSS properties, or dependencies. Since this just leaves a page with empty tables, do we still want to create a page for the `<dwc-app-nav>` client component?