### PR TITLE
config: Set webforJ version to 25.00 and removed methods from 25.01

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <webforj.version>25.01-SNAPSHOT</webforj.version>
+    <webforj.version>25.00</webforj.version>
     <warFileName>${project.artifactId}-${project.version}</warFileName>
     <jetty.version>12.0.14</jetty.version>
     <!--

--- a/src/main/java/com/webforj/samples/views/terminal/ServerLogsView.java
+++ b/src/main/java/com/webforj/samples/views/terminal/ServerLogsView.java
@@ -42,7 +42,7 @@ public class ServerLogsView extends Composite<FlexLayout> {
     printHelp();
 
     terminal.setAutoFit(true)
-        .setStyle("margin", "0px var(--dwc-space-m)")
+        // .setStyle("margin", "0px var(--dwc-space-m)")
         .setSize("95%", "85vh");
 
     startButton

--- a/src/main/java/com/webforj/samples/views/terminal/TerminalThemePickerView.java
+++ b/src/main/java/com/webforj/samples/views/terminal/TerminalThemePickerView.java
@@ -34,8 +34,8 @@ public class TerminalThemePickerView extends Composite<FlexLayout> {
         .setMaxWidth("800px");
 
     terminal
-        .setStyle("margin", "0px var(--dwc-space-m)")
-        .setStyle("border", "1px solid var(--dwc-color-default)")
+        // .setStyle("margin", "0px var(--dwc-space-m)")
+        // .setStyle("border", "1px solid var(--dwc-color-default)")
         .setSize("100%", "400px")
         .writeln(
             """

--- a/src/main/java/com/webforj/samples/views/terminal/TerminalView.java
+++ b/src/main/java/com/webforj/samples/views/terminal/TerminalView.java
@@ -39,7 +39,7 @@ public class TerminalView extends Composite<Terminal> {
   public TerminalView() {
     self.setAutoFit(true)
         .setSize("95%", "95%")
-        .setStyle("margin", "var(--dwc-space-m)")
+        // .setStyle("margin", "var(--dwc-space-m)")
         .addDataListener(this::onData);
 
     self.writeln("\u001B[1;32mWelcome 👋  to the webforJ terminal!\u001B[0m");


### PR DESCRIPTION
This PR changes the configuration to use the latest non-snapshot build of webforJ, 25.00. `Terminal.setStyle()` is only in webforJ 25.01 and higher, so it's commented out until the 25.01 build is officially released.