### PR TITLE
feat: add has, new, updated content badges

### DIFF
--- a/docs/docs/advanced/namespaces.md
+++ b/docs/docs/advanced/namespaces.md
@@ -1,5 +1,6 @@
 ---
 title: Namespaces
+sidebar_class_name: new-content
 ---
 
 Namespaces in webforJ provide a mechanism for storing and retrieving shared data across different scopes in a web app. They enable inter-component and cross-session data communication without relying on traditional storage techniques like session attributes or static fields. This abstraction allows developers to encapsulate and access state in a controlled, thread-safe manner. Namespaces are ideal for building multi-user collaboration tools or simply maintaining consistent global settings, and let you coordinate data safely and efficiently.

--- a/docs/docs/advanced/object-string-tables.md
+++ b/docs/docs/advanced/object-string-tables.md
@@ -1,5 +1,6 @@
 ---
 title: Object and String Tables
+sidebar_class_name: new-content
 ---
 
 The `ObjectTable` and `StringTable` provide static access to shared data in a webforJ environment. Both are accessible from anywhere in your app and serve different purposes:

--- a/docs/docs/advanced/overview.md
+++ b/docs/docs/advanced/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Advanced Topics
 hide_table_of_contents: true
+sidebar_class_name: has-new-content
 ---
 
 

--- a/docs/docs/components/alert.md
+++ b/docs/docs/components/alert.md
@@ -1,6 +1,7 @@
 ---
 title: Alert
 sidebar_position: 5
+sidebar_class_name: new-content
 ---
 
 <DocChip chip='shadow' />

--- a/docs/docs/components/appnav.md
+++ b/docs/docs/components/appnav.md
@@ -1,6 +1,7 @@
 ---
 title: AppNav
 sidebar_position: 6
+sidebar_class_name: new-content
 ---
 
 <DocChip chip="shadow" />

--- a/docs/docs/components/desktop-notification.md
+++ b/docs/docs/components/desktop-notification.md
@@ -1,6 +1,7 @@
 ---
 title: DesktopNotification
 sidebar_position: 29
+sidebar_class_name: new-content
 ---
 
 <JavadocLink type="desktopnotification" location="com/webforj/component/desktopnotification/DesktopNotification" top='true'/>

--- a/docs/docs/components/fields/masked/overview.md
+++ b/docs/docs/components/fields/masked/overview.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Masked Fields
 hide_table_of_contents: true
+sidebar_class_name: new-content
 ---
 
 <Head>

--- a/docs/docs/components/fields/overview.md
+++ b/docs/docs/components/fields/overview.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 20
 title: Fields
+sidebar_class_name: has-new-content
 ---
 
 <JavadocLink type="foundation" location="com/webforj/component/field/AbstractField"/>

--- a/docs/docs/components/overview.md
+++ b/docs/docs/components/overview.md
@@ -2,6 +2,7 @@
 title: UI Components
 sidebar_position: 85
 hide_table_of_contents: true
+sidebar_class_name: has-new-content
 ---
 
 <Head>

--- a/docs/docs/components/slider.md
+++ b/docs/docs/components/slider.md
@@ -1,6 +1,7 @@
 ---
 title: Slider
 sidebar_position: 101
+sidebar_class_name: updated-content
 ---
 
 <DocChip chip="shadow" />

--- a/docs/docs/components/table/overview.md
+++ b/docs/docs/components/table/overview.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 1
 title: Table
+sidebar_class_name: has-new-content
 ---
 
 import FiberSmartRecordIcon from '@mui/icons-material/FiberSmartRecord';

--- a/docs/docs/components/table/table_dynamic_styling.md
+++ b/docs/docs/components/table/table_dynamic_styling.md
@@ -2,6 +2,7 @@
 sidebar_position: 21
 title: Dynamic Styling
 slug: styling
+sidebar_class_name: new-content
 ---
 
 in webforJ 25 and higher, it's possible to style individual rows and cells in the Table using custom part names. These names can be assigned dynamically based on your app's logic, giving you fine-grained control over the table’s appearance.

--- a/docs/docs/components/terminal.md
+++ b/docs/docs/components/terminal.md
@@ -1,6 +1,7 @@
 ---
 title: Terminal
 sidebar_position: 126
+sidebar_class_name: new-content
 ---
 
 <DocChip chip="shadow" />  

--- a/docs/docs/components/toolbar.md
+++ b/docs/docs/components/toolbar.md
@@ -1,6 +1,7 @@
 ---
 title: Toolbar
 sidebar_position: 145
+sidebar_class_name: new-content
 ---
 
 <DocChip chip="shadow" />

--- a/docs/docs/managing-resources/overview.md
+++ b/docs/docs/managing-resources/overview.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Managing Resources
 hide_table_of_contents: true
+sidebar_class_name: new-content
 ---
 
 <Head>

--- a/docs/docs/styling/overview.md
+++ b/docs/docs/styling/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Styling
 hide_table_of_contents: true
+sidebar_class_name: new-content
 ---
 
 <Head>

--- a/docs/src/css/_sidebar.scss
+++ b/docs/src/css/_sidebar.scss
@@ -19,7 +19,7 @@
   .menu__list-item.updated-content a:after,
   .menu__list-item.new-content a:after {
     box-sizing: border-box;
-    padding: 0.25rem 0.5rem;
+    padding: 0.15rem 0.5rem;
     margin-left: .5rem;
     font-weight: 400;
     border-radius: 9999px;

--- a/docs/src/css/_sidebar.scss
+++ b/docs/src/css/_sidebar.scss
@@ -15,4 +15,58 @@
     margin-left: var(--ifm-menu-link-padding-horizontal);
     border-left: thin dotted var(--menu-level-indicator-color);
   }
+
+  .menu__list-item.updated-content a:after,
+  .menu__list-item.new-content a:after {
+    box-sizing: border-box;
+    padding: 0.25rem 0.5rem;
+    margin-left: .5rem;
+    font-weight: 400;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    transform: rotateZ(0deg) !important;
+  }
+
+  .theme-doc-sidebar-item-category.new-content ul a:after,
+  .theme-doc-sidebar-item-category.updated-content ul a:after {
+    display: none;
+  }
+
+  .menu__list-item.new-content a:after {
+    content: "New";
+    border: 1px solid var(--dwc-color-primary-85);
+    background-color: var(--dwc-color-primary-alt);
+    color: var(--dwc-color-primary);
+  }
+
+  .menu__list-item.updated-content a:after {
+    content: "Updated";
+    border: 1px solid var(--dwc-color-gray-85);
+    background-color: var(--dwc-color-gray-alt);
+    color: var(--dwc-color-gray);
+  }
+
+  .has-new-content > .menu__list-item-collapsible a:after {
+    content: "";
+    display: block;
+    width: 0.25rem;
+    height: 0.25rem;
+    background-color: var(--dwc-color-primary);
+    border-radius: 50%;
+    margin-left: .5rem;
+    margin-top: 0.25rem;
+    animation: pulse 1.5s infinite ease-in-out;
+  }
+
+  @keyframes pulse {
+    0%, 100% {
+      transform: scale(1);
+      opacity: 1;
+    }
+    50% {
+      transform: scale(1.5);
+      opacity: 0.5;
+    }
+  }
+
 }


### PR DESCRIPTION
This PR introduces custom badges to highlight new and updated content. It also includes a badge for sections that contain new or updated content. The goal is to create a consistent framework that makes it easier to spot recent changes in the documentation.

Right now, these badges are only used in the sidebar menu. We might want to consider adding them to the components page as well.

All, please review and share any feedback, both in terms of content and user experience. I’m especially interested to know if you find the badges too distracting or annoying, given that the docs are frequently updated. Do you have better suggestions for making new changes more noticeable?

Badge types:

1. **New content** – for brand new articles or entirely new sections.
2. **Updated content** – for existing articles or sections that have received major or noticeable updates.
3. **Has new content** – used at the section level to indicate that new or updated articles exist within that section (you can expect to see either of the above badges on child items).


<img width="1178" alt="has-new" src="https://github.com/user-attachments/assets/d3202247-83e1-4cc6-984b-f0d9f6ade47f" />
<hr/>
<img width="1170" alt="updated" src="https://github.com/user-attachments/assets/99185a45-dd06-4cb4-b6aa-34a37541fc1f" />
