### PR TITLE
style: Added animation to `FlexBasisView` sample

### DIFF
--- a/src/main/java/com/webforj/samples/views/flexlayout/FlexBasisView.java
+++ b/src/main/java/com/webforj/samples/views/flexlayout/FlexBasisView.java
@@ -47,8 +47,10 @@ public class FlexBasisView extends Composite<Div> {
 
     for (int i = 1; i <= 5; i++) {
       Button newButton = new Button("Box " + i, ButtonTheme.OUTLINED_PRIMARY, this::onButtonSelect);
+      newButton.setStyle("transition","flex-basis var(--dwc-transition-medium) var(--dwc-ease-inOutExpo)");
       buttons.add(newButton);
       boxLayout.add(buttons.get(i - 1));
+      boxLayout.setItemBasis("75px", buttons.get(i - 1));
     }
 
     this.numberField = new NumberField("Basis")
@@ -87,7 +89,7 @@ public class FlexBasisView extends Composite<Div> {
         if (buttons.get(i).getTheme() == ButtonTheme.PRIMARY) {
           boxLayout.setItemBasis(numberField.getValue().toString() + "px", buttons.get(i));
         } else {
-          boxLayout.setItemBasis("auto", buttons.get(i));
+          boxLayout.setItemBasis("75px", buttons.get(i));
         }
       }
     }
@@ -98,7 +100,7 @@ public class FlexBasisView extends Composite<Div> {
     selected = 0;
     for (int i = 0; i <= buttons.size() - 1; i++) {
       buttons.get(i).setTheme(ButtonTheme.OUTLINED_PRIMARY);
-      boxLayout.setItemBasis("auto", buttons.get(i));
+      boxLayout.setItemBasis("75px", buttons.get(i));
     }
   }
 }


### PR DESCRIPTION
This PR improves the [`FlexBasisView`](https://docs.webforj.com/webforj/flexbasis) sample by adding a smooth animation whenever the basis value is changed.

## Before
https://github.com/user-attachments/assets/641a88cb-df35-4e82-988d-9b856abfda33

## After
https://github.com/user-attachments/assets/3891eeed-f418-42e0-8524-f19783276ed1

Side Note: Because auto values aren't detected by transitions, I changed the "default" basis for this sample from auto to 75px. 