### PR TITLE
feat: Added `since` badge

### DIFF
--- a/docs/docs/advanced/browser-console.md
+++ b/docs/docs/advanced/browser-console.md
@@ -3,8 +3,8 @@ sidebar_position: 15
 title: Browser Console
 ---
 
-import ComponentDemo from '@site/src/components/DocsTools/ComponentDemo';
-import JavadocLink from '@site/src/components/DocsTools/JavadocLink';
+<DocChip chip='since' label='24.10' />
+<JavadocLink type="foundation" location="com/webforj/BrowserConsole" top='true'/>
 
 Using the browser's console to print valuable program information is an integral part of the development process. The <JavadocLink type="foundation" location="com/webforj/BrowserConsole" code='true'>BrowserConsole</JavadocLink> utility class comes with a slew of features to enhance logging capabilities.
 

--- a/docs/docs/advanced/browser-history.md
+++ b/docs/docs/advanced/browser-history.md
@@ -2,6 +2,9 @@
 title: Browser History
 ---
 
+<DocChip chip='since' label='24.12' />
+<JavadocLink type="foundation" location="com/webforj/router/history/BrowserHistory" top='true'/>
+
 The `BrowserHistory` class in webforJ provides a high-level API to interact with the browser's history. Browser history allows web applications to keep track of the user's navigation within the app. By leveraging browser history, developers can enable features like back and forward navigation, state preservation, and dynamic URL management without requiring full-page reloads.
 
 ## Navigating through history

--- a/docs/docs/advanced/interval.md
+++ b/docs/docs/advanced/interval.md
@@ -2,8 +2,9 @@
 sidebar_position: 45
 title: Interval
 ---
-import ComponentDemo from '@site/src/components/DocsTools/ComponentDemo';
-import JavadocLink from '@site/src/components/DocsTools/JavadocLink';
+
+<DocChip chip='since' label='24.02' />
+<JavadocLink type="foundation" location="com/webforj/Interval" top='true'/>
 
 The <JavadocLink type="foundation" location="com/webforj/Interval" code='true' >Interval</JavadocLink> class represents a timer that triggers an [event](../building-ui/events) with a fixed time delay between each triggering.
 

--- a/docs/docs/advanced/namespaces.md
+++ b/docs/docs/advanced/namespaces.md
@@ -3,6 +3,9 @@ title: Namespaces
 sidebar_class_name: new-content
 ---
 
+<DocChip chip='since' label='24.22' />
+<JavadocLink type="foundation" location="com/webforj/environment/namespace/Namespace" top='true'/>
+
 Namespaces in webforJ provide a mechanism for storing and retrieving shared data across different scopes in a web app. They enable inter-component and cross-session data communication without relying on traditional storage techniques like session attributes or static fields. This abstraction allows developers to encapsulate and access state in a controlled, thread-safe manner. Namespaces are ideal for building multi-user collaboration tools or simply maintaining consistent global settings, and let you coordinate data safely and efficiently.
 
 ## What's a namespace?

--- a/docs/docs/advanced/terminate-and-error-actions.md
+++ b/docs/docs/advanced/terminate-and-error-actions.md
@@ -1,6 +1,9 @@
 ---
 title: Terminate and Error Actions
 ---
+<!-- vale off -->
+# Terminate and Error Actions <DocChip chip='since' label='23.06' />
+<!-- vale on -->
 
 When developing applications with the webforJ, it's essential to define how your app behaves when it terminates or encounters an error. The framework provides mechanisms to customize these behaviors through `terminate` and `error` actions.
 

--- a/docs/docs/advanced/web-storage.md
+++ b/docs/docs/advanced/web-storage.md
@@ -2,8 +2,9 @@
 sidebar_position: 30
 title: Web Storage
 ---
-import JavadocLink from '@site/src/components/DocsTools/JavadocLink';
-
+<!-- vale off -->
+# Web Storage <DocChip chip='since' label='23.06' />
+<!-- vale on -->
 
 [Web storage](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API) is a fundamental concept in web development that allows websites to store data on the client side. This enables web applications to save state, preferences, and other information locally on the user's browser. Web storage provides a way to persist data across page reloads and browser sessions, reducing the need for repeated server requests and enabling offline capabilities.
 

--- a/docs/docs/building-ui/component-basics.md
+++ b/docs/docs/building-ui/component-basics.md
@@ -5,6 +5,7 @@ slug: basics
 draft: false
 ---
 
+<DocChip chip='since' label='23.05' />
 <JavadocLink type="foundation" location="com/webforj/component/Component" top='true'/>
 
 Components are fundamental building blocks that can be added to a window, providing user interface functionality and custom behavior. In webforJ, the `Component` class serves as the foundation for all components within the engine.

--- a/docs/docs/building-ui/composite-components.md
+++ b/docs/docs/building-ui/composite-components.md
@@ -4,6 +4,7 @@ title: Composite Components
 draft: false
 ---
 
+<DocChip chip='since' label='23.06' />
 <JavadocLink type="foundation" location="com/webforj/component/Composite" top='true'/>
 
 Developers will often wish to create components that contain constituent components for application level use. The `Composite` component gives developers the tools they need to create their own components while maintaining control over what they choose to expose to users. 

--- a/docs/docs/building-ui/element-composite.md
+++ b/docs/docs/building-ui/element-composite.md
@@ -4,6 +4,7 @@ title: Element Composite
 slug: element_composite
 ---
 
+<DocChip chip='since' label='23.06' />
 <JavadocLink type="foundation" location="com/webforj/component/element/ElementComposite" top='true'/>
 
 The `ElementComposite` class serves as a versatile foundation for managing composite elements in webforJ applications. Its primary purpose is to facilitate the interaction with HTML elements, represented by the `Element` class, by providing a structured approach to handle properties, attributes, and event listeners. It allows for implementation and reuse of elements in an application. Use the `ElementComposite` class when implementing Web Components for use in webforJ applications.

--- a/docs/docs/building-ui/elements.md
+++ b/docs/docs/building-ui/elements.md
@@ -4,6 +4,7 @@ title: Elements
 slug: element
 ---
 
+<DocChip chip='since' label='23.06' />
 <JavadocLink type="foundation" location="com/webforj/component/element/Element" top='true'/>
 
 webforJ developers have the option of choosing not only from the rich library of components provided, but also integrating components from elsewhere. To facilitate this, the `Element` component can be used to simplify the integration of anything from simple HTML elements, to more complex custom web components. 

--- a/docs/docs/components/alert.md
+++ b/docs/docs/components/alert.md
@@ -6,6 +6,7 @@ sidebar_class_name: new-content
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-alert" />
+<DocChip chip='since' label='25.00' />
 <JavadocLink type="alert" location="com/webforj/component/alert/Alert" top='true'/>
 
 The `Alert` component in webforJ provides contextual feedback messages for users. It's a versatile way to display important information, warnings, or notifications in your app.

--- a/docs/docs/components/app-layout.md
+++ b/docs/docs/components/app-layout.md
@@ -5,6 +5,7 @@ sidebar_position: 5
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-app-layout" />
+<DocChip chip='since' label='23.06' />
 <JavadocLink type="applayout" location="com/webforj/component/layout/applayout/AppLayout" top='true'/>
 
 The `AppLayout` is a comprehensive responsive layout component that provides a header, a footer, a drawer, and content section. The header and footer are fixed, the drawer slides in and out of the viewport, and the content is scrollable.

--- a/docs/docs/components/appnav.md
+++ b/docs/docs/components/appnav.md
@@ -7,6 +7,7 @@ sidebar_class_name: new-content
 <DocChip chip="shadow" />
 <DocChip chip="name" label="dwc-app-nav" />
 <DocChip chip="name" label="dwc-app-nav-item" />
+<DocChip chip='since' label='24.12' />
 <JavadocLink type="appnav" location="com/webforj/component/appnav/AppNav" top='true'/> 
 
 The `AppNav` component in webforJ provides a flexible and organized side navigation menu with support for both flat and hierarchical structures. Each entry is an `AppNavItem`, which can represent a simple link or a group containing sub-items. Items can be linked to internal views or external resources, enhanced with icons, badges, or other components.

--- a/docs/docs/components/busyindicator.md
+++ b/docs/docs/components/busyindicator.md
@@ -4,10 +4,8 @@ sidebar_position: 10
 ---
 
 <DocChip chip="shadow" />
-
 <DocChip chip="name" label="dwc-loading" />
-
-
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="foundation" location="com/webforj/BusyIndicator" top='true'/>
 
 The `BusyIndicator` provides visual cues to ensure that users are aware of ongoing processes, preventing them from interacting with the system prematurely. It typically covers the entire app interface for global operations.

--- a/docs/docs/components/button.md
+++ b/docs/docs/components/button.md
@@ -3,14 +3,9 @@ title: Button
 sidebar_position: 15
 ---
 
-import FiberSmartRecordIcon from '@mui/icons-material/FiberSmartRecord';
-import Chip from '@mui/material/Chip';
-
 <DocChip chip="shadow" />
-
 <DocChip chip="name" label="dwc-button" />
-
-
+<DocChip chip='since' label='23.02' />
 <JavadocLink type="foundation" location="com/webforj/component/button/Button" top='true'/>
 
 A `Button` component is a fundamental user interface element used in application development to create interactive elements that trigger actions or events when clicked or activated. It serves as a clickable element that users can interact with to perform various actions within an application or website. 
@@ -50,7 +45,7 @@ The `Button` class is a versatile component that is commonly used in various sit
   > - "Previous" - Returns the user to the previous page of the application or section they're in.
   > - "Back" Returns the user to the first part of the application or page they're in.
 
-## Adding icons to buttons
+## Adding icons to buttons <DocChip chip='since' label='24.11' />
 
 Incorporating an icon into a button can greatly improve your app's design, allowing users to quickly identify actionable items on the screen. The [`Icon`](./icon.md) component provides a wide selection of icons to choose from.
 

--- a/docs/docs/components/checkbox.md
+++ b/docs/docs/components/checkbox.md
@@ -3,13 +3,9 @@ title: CheckBox
 sidebar_position: 20
 ---
 
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-
 <DocChip chip="shadow" />
-
 <DocChip chip="name" label="dwc-checkbox" />
-
+<DocChip chip='since' label='23.01' />
 <JavadocLink type="foundation" location="com/webforj/component/optioninput/CheckBox" top='true'/>
 
 The `CheckBox` class creates a component that can be selected or deselected, and which displays its state to the user. When clicked, a check mark appears inside the box, to indicate an affirmative choice (on). When clicked again, the check mark disappears, indicating a negative choice (off).

--- a/docs/docs/components/columns-layout.md
+++ b/docs/docs/components/columns-layout.md
@@ -4,9 +4,8 @@ sidebar_position: 25
 ---
 
 <DocChip chip="shadow" />
-
 <DocChip chip="name" label="dwc-columns-layout" />
-
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="columnslayout" location="com/webforj/component/layout/columnslayout/ColumnsLayout" top='true'/>
 
 The `ColumnsLayout` component in webforJ allows developers to create layouts using a flexible and responsive vertical layout. This layout provides dynamic columns that adjust based on the available width. This component simplifies the creation of multi-column layouts by automatically managing breakpoints and alignments.

--- a/docs/docs/components/desktop-notification.md
+++ b/docs/docs/components/desktop-notification.md
@@ -4,7 +4,8 @@ sidebar_position: 29
 sidebar_class_name: new-content
 ---
 
-<JavadocLink type="desktopnotification" location="com/webforj/component/desktopnotification/DesktopNotification" top='true'/>
+<DocChip chip='since' label='25.00' />
+<JavadocLink type="desktop-notification" location="com/webforj/component/desktopnotification/DesktopNotification" top='true'/>
 
 In webforj 25.00 and higher, The **DesktopNotification** component provides a simple interface for creating, displaying, and managing desktop notifications. With a focus on minimal configuration and built-in event handling, the component can be used when needing to notify users about real-time events (such as new messages, alerts, or system events) while they're browsing your app.
 

--- a/docs/docs/components/dialog.md
+++ b/docs/docs/components/dialog.md
@@ -4,9 +4,8 @@ sidebar_position: 30
 ---
 
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-dialog" />
-
+<DocChip chip='since' label='23.06' />
 <JavadocLink type="dialog" location="com/webforj/component/dialog/Dialog" top='true'/>
 
 The webforJ dialog component is built to allow a developer to quickly and easily display a dialog on their application, for instances such as a login menu or information box.

--- a/docs/docs/components/drawer.md
+++ b/docs/docs/components/drawer.md
@@ -4,6 +4,7 @@ sidebar_position: 35
 ---
 <DocChip chip="shadow" />
 <DocChip chip="name" label="dwc-drawer" />
+<DocChip chip='since' label='24.00' />
 <JavadocLink type="drawer" location="com/webforj/component/drawer/Drawer" top='true'/>
 
 The drawer is a container that slides into the viewport to expose additional options and information. Multiple drawers can be created in an application, and they will be stacked above each other.

--- a/docs/docs/components/fields/color-field.md
+++ b/docs/docs/components/fields/color-field.md
@@ -7,6 +7,7 @@ description: A component that provides a default browser-based color picker, all
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-color-chooser" />
+<DocChip chip='since' label='23.02' />
 <JavadocLink type="foundation" location="com/webforj/component/field/ColorField" top='true'/>
 
 <ParentLink parent="Field" />

--- a/docs/docs/components/fields/date-field.md
+++ b/docs/docs/components/fields/date-field.md
@@ -7,6 +7,7 @@ description: A component that provides a default browser-based date picker for s
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-field" />
+<DocChip chip='since' label='23.02' />
 <JavadocLink type="foundation" location="com/webforj/component/field/DateField" top='true'/>
 
 <ParentLink parent="Field" />

--- a/docs/docs/components/fields/date-time-field.md
+++ b/docs/docs/components/fields/date-time-field.md
@@ -7,6 +7,7 @@ description: A component that provides a default browser-based date and time pic
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-field" />
+<DocChip chip='since' label='23.02' />
 <JavadocLink type="foundation" location="com/webforj/component/field/DateTimeField" top='true'/>
 
 <ParentLink parent="Field" />

--- a/docs/docs/components/fields/masked/datefield.md
+++ b/docs/docs/components/fields/masked/datefield.md
@@ -5,6 +5,7 @@ sidebar_position: 5
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-datefield" />
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="foundation" location="com/webforj/component/field/MaskedDateField" top='true'/>
 
 The `MaskedDateField` is a text input control designed for structured date entry. It lets users enter dates as **numbers** and automatically formats the input based on a defined mask when the field loses focus. The mask is a string that specifies the expected date format, guiding both input and display.

--- a/docs/docs/components/fields/masked/numberfield.md
+++ b/docs/docs/components/fields/masked/numberfield.md
@@ -5,6 +5,7 @@ sidebar_position: 10
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-numberfield" />
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="foundation" location="com/webforj/component/field/MaskedNumberField" top='true'/>
 
 The `MaskedNumberField` is a text input designed for structured numeric entry. It ensures numbers are formatted consistently based on a defined mask, making it especially useful for financial forms, pricing fields, or any input where precision and readability matter.

--- a/docs/docs/components/fields/masked/textfield.md
+++ b/docs/docs/components/fields/masked/textfield.md
@@ -4,9 +4,8 @@ sidebar_position: 15
 ---
 
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-textfield" />
-
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="foundation" location="com/webforj/component/field/MaskedTextField" top='true'/>
 
 The `MaskedTextField` component aims to deliver a configurable and easily validatable text input. It's well-suited for apps requiring formatted input, such as financial, e-commerce, and healthcare apps.

--- a/docs/docs/components/fields/masked/timefield.md
+++ b/docs/docs/components/fields/masked/timefield.md
@@ -5,6 +5,7 @@ sidebar_position: 20
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-timefield" />
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="foundation" location="com/webforj/component/field/MaskedTimeField" top='true'/>
 
 The `MaskedTimeField` is a text input control designed for precise, structured time entry. It lets users enter times as **numbers** and automatically formats the input based on a defined mask when the field loses focus. The mask is a string that specifies the expected time format, guiding both input and display.

--- a/docs/docs/components/fields/number-field.md
+++ b/docs/docs/components/fields/number-field.md
@@ -7,6 +7,7 @@ description: A component that provides a default browser-based input field for e
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-field" />
+<DocChip chip='since' label='23.02' />
 <JavadocLink type="foundation" location="com/webforj/component/field/NumberField" top='true' />
 
 <ParentLink parent="Field" />

--- a/docs/docs/components/fields/password-field.md
+++ b/docs/docs/components/fields/password-field.md
@@ -7,6 +7,7 @@ description: A single-line input component for securely entering and masking pas
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-field" />
+<DocChip chip='since' label='23.02' />
 <JavadocLink type="foundation" location="com/webforj/component/field/PasswordField" top='true'/>
 
 <ParentLink parent="Field" />

--- a/docs/docs/components/fields/text-field.md
+++ b/docs/docs/components/fields/text-field.md
@@ -7,6 +7,7 @@ description: A single-line input component for entering and editing text data.
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-field" />
+<DocChip chip='since' label='23.02' />
 <JavadocLink type="foundation" location="com/webforj/component/field/TextField" top='true'/>
 
 <ParentLink parent="Field" />

--- a/docs/docs/components/fields/time-field.md
+++ b/docs/docs/components/fields/time-field.md
@@ -7,6 +7,7 @@ description: A component that provides a default browser-based time picker for s
 
 <DocChip chip='shadow' />
 <DocChip chip='name' label="dwc-field" />
+<DocChip chip='since' label='23.02' />
 <JavadocLink type="foundation" location="com/webforj/component/field/TimeField" top='true'/>
 
 <ParentLink parent="Field" />

--- a/docs/docs/components/flex-layout.md
+++ b/docs/docs/components/flex-layout.md
@@ -4,7 +4,7 @@ sidebar_position: 45
 ---
 
 <JavadocLink type="flexlayout" location="com/webforj/component/layout/flexlayout/FlexLayout" top='true'/>
-
+<DocChip chip='since' label='24.00' />
 
 webforJ provides developers with an efficient and intuitive way to layout their various applications and components - the Flex Layout. This toolset allows for items to be displayed either vertically or horizontally. 
 

--- a/docs/docs/components/google-charts.md
+++ b/docs/docs/components/google-charts.md
@@ -3,13 +3,9 @@ title: Google Charts
 sidebar_position: 50
 ---
 
-import FiberSmartRecordIcon from '@mui/icons-material/FiberSmartRecord';
-import Chip from '@mui/material/Chip';
-
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="google-chart" exclude= 'true' />
-
+<DocChip chip='since' label='23.06' />
 <JavadocLink type="googlecharts" location="com/webforj/component/googlecharts/GoogleChart" top='true'/>
 
 <!-- Brief overview of the component and what it is/does -->

--- a/docs/docs/components/icon.md
+++ b/docs/docs/components/icon.md
@@ -3,9 +3,9 @@ title: Icon
 sidebar_position: 55
 ---
 
-
 <DocChip chip="shadow" />
 <DocChip chip="name" label="dwc-icon" />
+<DocChip chip='since' label='24.11' />
 <JavadocLink type="icons" location="com/webforj/component/icons/Icon" top='true'/>
 
 The webforJ `Icon` component allows you to include icons effortlessly in your user interface

--- a/docs/docs/components/infinitescroll.md
+++ b/docs/docs/components/infinitescroll.md
@@ -6,6 +6,7 @@ sidebar_class_name: new-content
 
 <DocChip chip="shadow" />
 <DocChip chip="name" label="dwc-infinite-scroll" />
+<DocChip chip='since' label='25.00' />
 <JavadocLink type="infinite-scroll" location="com/webforj/component/infinitescroll/InfiniteScroll" top='true'/>
 
 The `InfiniteScroll` component in webforJ automatically loads more content as users scroll down, eliminating the need for pagination. This creates a smooth experience for lists, feeds, and data-heavy views by loading content only when needed.

--- a/docs/docs/components/lists/choice-box.md
+++ b/docs/docs/components/lists/choice-box.md
@@ -5,9 +5,8 @@ slug: choicebox
 ---
 
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-choicebox" />
-
+<DocChip chip='since' label='23.05' />
 <JavadocLink type="foundation" location="com/webforj/component/list/ChoiceBox" top='true'/>
 
 <ParentLink parent="List" />

--- a/docs/docs/components/lists/combo-box.md
+++ b/docs/docs/components/lists/combo-box.md
@@ -5,9 +5,8 @@ slug: combobox
 ---
 
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-combobox" />
-
+<DocChip chip='since' label='23.05' />
 <JavadocLink type="foundation" location="com/webforj/component/list/ComboBox" top='true'/>
 
 <ParentLink parent="List" />

--- a/docs/docs/components/lists/list-box.md
+++ b/docs/docs/components/lists/list-box.md
@@ -5,9 +5,8 @@ slug: listbox
 ---
 
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-listbox" />
-
+<DocChip chip='since' label='23.05' />
 <JavadocLink type="foundation" location="com/webforj/component/list/ListBox" top='true'/>
 
 <ParentLink parent="List" />

--- a/docs/docs/components/loading.md
+++ b/docs/docs/components/loading.md
@@ -4,10 +4,8 @@ sidebar_position: 65
 ---
 
 <DocChip chip="shadow" />
-
 <DocChip chip="name" label="dwc-loading" />
-
-
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="loading" location="com/webforj/component/loading/Loading" top='true'/>
 
 The `Loading` component in webforJ displays an overlay that signals the processing of an operation, temporarily preventing user interaction until the task is complete. This feature improves the user experience, especially in situations where tasks like data loading, computations, or background processes may take some time. For global, app-wide processes, consider using the [`BusyIndicator`](../components/busyindicator) component, which blocks interaction across the entire interface.

--- a/docs/docs/components/login.md
+++ b/docs/docs/components/login.md
@@ -4,9 +4,8 @@ sidebar_position: 70
 ---
 
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-login" />
-
+<DocChip chip='since' label='24.01' />
 <JavadocLink type="login" location="com/webforj/component/login/Login" top='true'/>
 
 The Login component is designed to provide a and user-friendly interface for authentication, allowing users to log in using a username and password. It supports various customizations to enhance user experience across different devices and locales.

--- a/docs/docs/components/navigator.md
+++ b/docs/docs/components/navigator.md
@@ -3,20 +3,10 @@ title: Navigator
 sidebar_position: 75
 ---
 
-<!-- vale off -->
-
-import FiberSmartRecordIcon from '@mui/icons-material/FiberSmartRecord';
-import Chip from '@mui/material/Chip';
-
-<!-- vale on -->
-
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-navigator" />
-
-
+<DocChip chip='since' label='24.00' />
 <JavadocLink type="foundation" location="com/webforj/component/navigator/Navigator" top='true'/>
-
 
 The `Navigator` component is a customizable pagination component designed to navigate through data sets, supporting multiple layouts. You can configure it to display various navigation controls such as first, last, next, and previous buttons, along with page numbers or a quick jump field depending on the layout setting. 
 

--- a/docs/docs/components/option-dialogs/confirm.md
+++ b/docs/docs/components/option-dialogs/confirm.md
@@ -6,7 +6,7 @@ title: Confirm
 # Confirm Dialog
 
 <DocChip chip='shadow' />
-
+<DocChip chip='since' label='24.02' />
 <JavadocLink type="foundation" location="com/webforj/component/optiondialog/ConfirmDialog" top='true'/>
 
 A `ConfirmDialog` is a modal dialog designed to allow the user to choose one of a set of up to 3 options. The dialog blocks app execution until the user interacts with it or it closes due to a timeout.

--- a/docs/docs/components/option-dialogs/file-chooser.md
+++ b/docs/docs/components/option-dialogs/file-chooser.md
@@ -6,7 +6,7 @@ title: File Chooser
 # File Chooser Dialog
 
 <DocChip chip='shadow' />
-
+<DocChip chip='since' label='24.02' />
 <JavadocLink type="foundation" location="com/webforj/component/optiondialog/FileChooserDialog" top='true'/>
 
 `FileChooserDialog` is a modal dialog designed to allow the user to select a file or a directory from the server file system. The dialog blocks app execution until the user makes a selection or closes the dialog.

--- a/docs/docs/components/option-dialogs/file-save.md
+++ b/docs/docs/components/option-dialogs/file-save.md
@@ -6,7 +6,7 @@ title: File Save
 # File Save Dialog
 
 <DocChip chip='shadow' />
-
+<DocChip chip='since' label='24.21' />
 <JavadocLink type="foundation" location="com/webforj/component/optiondialog/FileSaveDialog" top='true'/>
 
 `FileSaveDialog` is a modal dialog designed to allow users to save a file to a specified location on the server file system. The dialog blocks app execution until the user provides a filename and confirms the action or cancels the dialog.

--- a/docs/docs/components/option-dialogs/file-upload.md
+++ b/docs/docs/components/option-dialogs/file-upload.md
@@ -6,7 +6,7 @@ title: File Upload
 # File Upload Dialog
 
 <DocChip chip='shadow' />
-
+<DocChip chip='since' label='24.02' />
 <JavadocLink type="foundation" location="com/webforj/component/optiondialog/FileUploadDialog" top='true'/>
 
 A `FileUploadDialog` is a modal dialog designed to allow the user to upload files from their local file system. The dialog blocks app execution until the user selects files to upload or closes the dialog.

--- a/docs/docs/components/option-dialogs/input.md
+++ b/docs/docs/components/option-dialogs/input.md
@@ -6,7 +6,7 @@ title: Input Dialog
 # Input Dialog
 
 <DocChip chip='shadow' />
-
+<DocChip chip='since' label='24.02' />
 <JavadocLink type="foundation" location="com/webforj/component/optiondialog/InputDialog" top='true'/>
 
 An `InputDialog` is a modal dialog designed to prompt the user for input. The dialog blocks app execution until the user provides the input or closes the dialog.

--- a/docs/docs/components/option-dialogs/message.md
+++ b/docs/docs/components/option-dialogs/message.md
@@ -6,7 +6,7 @@ title: Message
 # Message Dialog
 
 <DocChip chip='shadow' />
-
+<DocChip chip='since' label='24.02' />
 <JavadocLink type="foundation" location="com/webforj/component/optiondialog/MessageDialog" top='true'/>
 
 A `MessageDialog` is a modal dialog designed to display a message to the user with an `OK` button to dismiss the dialog. It blocks app execution until the user interacts with it or it closes due to a timeout.

--- a/docs/docs/components/progressbar.md
+++ b/docs/docs/components/progressbar.md
@@ -4,9 +4,8 @@ sidebar_position: 90
 ---
 
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-progressbar" />
-
+<DocChip chip='since' label='24.02' />
 <JavadocLink type="foundation" location="com/webforj/component/progressbar/ProgressBar" top='true'/>
 
 ProgressBar is component that visually displays the progress of some task. As the task progresses towards completion, the progress bar displays the task's percentage of completion. This percentage is represented visually by a rectangle which starts out empty and gradually becomes filled in as the task progresses. In addition, the progress bar can display a textual representation of this percentage.

--- a/docs/docs/components/radio-button.md
+++ b/docs/docs/components/radio-button.md
@@ -4,13 +4,9 @@ slug: radiobutton
 sidebar_position: 95
 ---
 
-import FiberSmartRecordIcon from '@mui/icons-material/FiberSmartRecord';
-import Chip from '@mui/material/Chip';
-
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-radio" />
-
+<DocChip chip='since' label='23.01' />
 <JavadocLink type="foundation" location="com/webforj/component/optioninput/RadioButton" top='true'/>
 
 The `RadioButton` class creates an object that can be selected or deselected, and which displays its state to the user. By convention, only one radio button in a group can be selected at a time. Radio buttons are commonly used when mutually exclusive options are available, allowing the user to choose a single option from a set of choices.

--- a/docs/docs/components/radio-group.md
+++ b/docs/docs/components/radio-group.md
@@ -4,6 +4,7 @@ slug: radiobuttongroup
 sidebar_position: 100
 ---
 
+<DocChip chip='since' label='23.01' />
 <JavadocLink type="foundation" location="com/webforj/component/optioninput/RadioButtonGroup" top='true'/>
 
 The `RadioButtonGroup` class is used to group related radio buttons together, which helps establish the mutual exclusivity among the options within that group. Users can select only one radio button within a given radio group. When a user selects a radio button within a group, any previously selected radio button in the same group automatically becomes deselected. This ensures that only one option can be chosen at a time.

--- a/docs/docs/components/refresher.md
+++ b/docs/docs/components/refresher.md
@@ -6,6 +6,7 @@ sidebar_class_name: new-content
 
 <DocChip chip="shadow" />
 <DocChip chip="name" label="dwc-refresher" />
+<DocChip chip='since' label='25.00' />
 <JavadocLink type="refresher" location="com/webforj/component/refresher/Refresher" top='true'/>
 
 The `Refresher` component in webforJ enables a pull-to-refresh interaction within scrollable containers—ideal for dynamic data loading in mobile or tap-friendly interfaces. As users swipe downward past a configurable threshold, the refresher transitions through visual states: `pull`, `release`, and `refreshing`. Each state presents a customizable icon and localized text to clearly communicate feedback.

--- a/docs/docs/components/slider.md
+++ b/docs/docs/components/slider.md
@@ -6,6 +6,7 @@ sidebar_class_name: updated-content
 
 <DocChip chip="shadow" />
 <DocChip chip="name" label="dwc-slider" />
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="foundation" location="com/webforj/component/slider/Slider" top='true'/>
 
 The `Slider` component in webforJ provides an interactive control that allows users to select a value within a specific range by moving a knob. This feature is particularly useful for apps requiring precise or intuitive input, such as selecting volumes, percentages, or other adjustable values.

--- a/docs/docs/components/spinner.md
+++ b/docs/docs/components/spinner.md
@@ -4,10 +4,8 @@ sidebar_position: 110
 ---
 
 <DocChip chip="shadow" />
-
 <DocChip chip="name" label="dwc-spinner" />
-
-
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="spinner" location="com/webforj/component/spinner/Spinner" top='true'/>
 
 The `Spinner` component provides a visual indicator that indicates ongoing processing or loading in the background. It's often used to show that the system is fetching data or when a process takes time to complete. The spinner offers user feedback, signaling that the system is actively working.

--- a/docs/docs/components/splitter.md
+++ b/docs/docs/components/splitter.md
@@ -3,18 +3,9 @@ title: Splitter
 sidebar_position: 115
 ---
 
-<!-- vale off -->
-
-import FiberSmartRecordIcon from '@mui/icons-material/FiberSmartRecord';
-import Chip from '@mui/material/Chip';
-
-<!-- vale on -->
-
-
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-splitter" />
-
+<DocChip chip='since' label='24.00' />
 <JavadocLink type="splitter" location="com/webforj/component/layout/splitter/Splitter" top='true'/>
 
 

--- a/docs/docs/components/tabbed-pane.md
+++ b/docs/docs/components/tabbed-pane.md
@@ -4,13 +4,9 @@ slug: tabbedpane
 sidebar_position: 125
 ---
 
-import FiberSmartRecordIcon from '@mui/icons-material/FiberSmartRecord';
-import Chip from '@mui/material/Chip';
-
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-tabbed-pane" />
-
+<DocChip chip='since' label='23.06' />
 <JavadocLink type="foundation" location="com/webforj/component/tabbedpane/TabbedPane" top='true'/>
 
 The `TabbedPane` class provides a compact and organized way of displaying content that is divided into multiple sections, each associated with a `Tab`. Users can switch between these sections by clicking on the respective tabs, often labeled with text and/or icons. This class simplifies the creation of multifaceted interfaces where different content or forms need to be accessible but not simultaneously visible.

--- a/docs/docs/components/table/overview.md
+++ b/docs/docs/components/table/overview.md
@@ -4,13 +4,9 @@ title: Table
 sidebar_class_name: has-new-content
 ---
 
-import FiberSmartRecordIcon from '@mui/icons-material/FiberSmartRecord';
-import Chip from '@mui/material/Chip';
-
 <DocChip chip='shadow' />
-
 <DocChip chip='name' label="dwc-table" />
-
+<DocChip chip='since' label='24.00' />
 <JavadocLink type="table" location="com/webforj/component/table/Table" top='true'/>
 
 The `Table` class is a versatile component designed for presenting tabular information in a structured and easily understandable manner. Optimized for handling large datasets with high performance, this component offers advanced visualization and a comprehensive suite of events for dynamic user engagement.

--- a/docs/docs/components/table/table_columns.md
+++ b/docs/docs/components/table/table_columns.md
@@ -4,6 +4,9 @@ title: Columns
 slug: columns
 ---
 
+<DocChip chip='since' label='24.00' />
+<JavadocLink type="table" location="com/webforj/component/table/Column" top='true'/>
+
 The `Table` class utilizes `Column` classes to handle the creation of data columns within it. This class has a wide range of functionality that allows a user to thoroughly customize what is displayed within each of the columns.
 To add a `Column` to a `Table`, use one of the `addColumn` factory methods.
 

--- a/docs/docs/components/table/table_dynamic_styling.md
+++ b/docs/docs/components/table/table_dynamic_styling.md
@@ -4,8 +4,11 @@ title: Dynamic Styling
 slug: styling
 sidebar_class_name: new-content
 ---
+<!-- vale off -->
+# Dynamic Styling <DocChip chip='since' label='25.00' />
+<!-- vale on -->
 
-in webforJ 25 and higher, it's possible to style individual rows and cells in the Table using custom part names. These names can be assigned dynamically based on your app's logic, giving you fine-grained control over the table’s appearance.
+In webforJ 25 and higher, it's possible to style individual rows and cells in the Table using custom part names. These names can be assigned dynamically based on your app's logic, giving you fine-grained control over the table’s appearance.
 
 ## Row styling
 

--- a/docs/docs/components/terminal.md
+++ b/docs/docs/components/terminal.md
@@ -5,7 +5,8 @@ sidebar_class_name: new-content
 ---
 
 <DocChip chip="shadow" />  
-<DocChip chip="name" label="dwc-terminal" />  
+<DocChip chip="name" label="dwc-terminal" />
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="terminal" location="com/webforj/component/terminal/Terminal" top='true'/>
 
 The `Terminal` component provides an interactive terminal emulator that behaves much like a traditional system console. It allows applications to display and manipulate a text-based interface, handling text output, receiving user input, interpreting control sequences, and maintaining screen buffers.

--- a/docs/docs/components/textarea.md
+++ b/docs/docs/components/textarea.md
@@ -4,9 +4,8 @@ sidebar_position: 130
 ---
 
 <DocChip chip="shadow" />
-
 <DocChip chip="name" label="dwc-textarea" />
-
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="foundation" location="com/webforj/component/field/TextArea" top='true'/>
 
 The `TextArea` component in webforJ offers a solution for multi-line text input. End-users can freely type and edit text, while developers can set reasonable boundaries using features like maximum character limits, paragraph structure, and validation rules.

--- a/docs/docs/components/toast.md
+++ b/docs/docs/components/toast.md
@@ -4,9 +4,8 @@ sidebar_position: 140
 ---
 
 <DocChip chip="shadow" />
-
 <DocChip chip="name" label="dwc-toast" />
-
+<DocChip chip='since' label='24.10' />
 <JavadocLink type="toast" location="com/webforj/component/toast/Toast" top='true'/>
 
 A `Toast` notification is a subtle and unobtrusive pop-up notification designed to provide users with real-time feedback and information. These notifications are typically used to inform users about operations such as successful actions, warnings, or errors without interrupting their workflow. `Toast` notifications typically disappear after a set amount of time and don't require a user response.

--- a/docs/docs/components/toolbar.md
+++ b/docs/docs/components/toolbar.md
@@ -6,6 +6,7 @@ sidebar_class_name: new-content
 
 <DocChip chip="shadow" />
 <DocChip chip="name" label="dwc-toolbar" />
+<DocChip chip='since' label='24.12' />
 <JavadocLink type="toolbar" location="com/webforj/component/layout/toolbar/Toolbar" top='true'/>
 
 Toolbars offer users quick access to core actions and navigation elements. The webforJ `Toolbar` component is a horizontal container that can hold a set of action buttons, icons, or other components. It's well-suited for managing page controls and housing key functions like a search bar or a notification button.

--- a/docs/docs/components/tree.md
+++ b/docs/docs/components/tree.md
@@ -6,6 +6,7 @@ sidebar_class_name: new-content
 
 <DocChip chip="shadow" />
 <DocChip chip="name" label="dwc-tree" />
+<DocChip chip='since' label='25.01' />
 <JavadocLink type="tree" location="com/webforj/component/layout/tree/Tree" top='true'/>
 
 The `Tree` component organizes data as a hierarchy of nodes. Each node holds a unique key and a label. Nodes connect to form parent-child relationships. You can expand or collapse nodes to show or hide their children. Icons clarify what kind of node you’re looking at and whether it’s selected. Selection supports choosing one node or many at once.

--- a/docs/docs/configuration/installable-apps.md
+++ b/docs/docs/configuration/installable-apps.md
@@ -3,6 +3,9 @@ title: Installable Apps
 sidebar_position: 10
 ---
 
+<DocChip chip='since' label='24.21' />
+<JavadocLink type="foundation" location="com/webforj/annotation/AppProfile" top='true'/>
+
 The `@AppProfile` annotation in webforJ enables you to make your app installable on supported platforms. 
 Installable web apps integrate seamlessly with the device's operating system. 
 When installed, they appear on the home screen or app menu, similar to native apps. 

--- a/docs/docs/testing/property-descriptor-tester.md
+++ b/docs/docs/testing/property-descriptor-tester.md
@@ -3,6 +3,9 @@ sidebar_position: 4
 title: PropertyDescriptorTester
 ---
 
+<DocChip chip='since' label='23.06' />
+<JavadocLink type="foundation" location="com/webforj/component/element/PropertyDescriptorTester" top='true'/>
+
 The `PropertyDescriptorTester` in webforJ simplifies testing for **third-party web components** integrated into your app. It validates that properties defined with [`PropertyDescriptor`](https://javadoc.io/doc/com.webforj/webforj-foundation/latest/com/webforj/component/element/PropertyDescriptor.html) are correctly linked to their getter and setter methods and ensures that default behaviors are handled consistently. This tool is especially useful for verifying the functionality of properties exposed by third-party components without requiring repetitive test logic.
 
 :::warning experimental feature

--- a/docs/src/components/DocsTools/DocChip.js
+++ b/docs/src/components/DocsTools/DocChip.js
@@ -4,19 +4,20 @@ import { jsx, css } from '@emotion/react';
 import { Tooltip, Chip } from '@mui/material';
 
 import BiotechIcon from '@mui/icons-material/Biotech';
+import AddTaskIcon from '@mui/icons-material/AddTask';
 import FiberSmartRecordIcon from '@mui/icons-material/FiberSmartRecord';
 import CodeIcon from '@mui/icons-material/Code';
 import DescriptionIcon from '@mui/icons-material/Description';
-import StyleIcon from '@mui/icons-material/Style';
 
-export default function DocChip( { chip, label, href, exclude, iconName, tooltipText, color  } ) {
+export default function DocChip( { chip, label, href, exclude, tooltipText, color } ) {
 
   const mainStyles = css`
     margin-right: 0.5em;
     margin-bottom: 1em;
     background-color: var(--chip-background);
     color: var(--chip-text);
-
+    position: relative;
+    top: 0.3rem;
     :hover{
       color: inherit;
       background-color: var(--chip-background-hover);
@@ -28,36 +29,41 @@ export default function DocChip( { chip, label, href, exclude, iconName, tooltip
   `
 
   let icon;
-  if(chip === 'shadow'){
-    // A "Shadow DOM" Chip
-    tooltipText = "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.";
-    href = "/docs/glossary#shadow-dom";
-    label='Shadow';
-    iconName = 'shadow';
-  } else if (chip === 'name') {
+  switch(chip){
+    // A "Shadow DOM" chip
+    case 'shadow':
+      tooltipText = "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.";
+      href = "/docs/glossary#shadow-dom";
+      label = 'Shadow';
+      icon = <FiberSmartRecordIcon css={iconStyles} />;
+    break;
     // A "DOM Name" chip
-    tooltipText="The name of this web component as it appears in the DOM.";
-      if (!(exclude)){
-        const path = "/docs/client-components/";
-        const clientPage = label.replace("dwc-", "");
-        href = path.concat(clientPage);
-      }
-    iconName = 'code';
-  } else if (chip == 'scoped') {
-    tooltipText = "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.";
-    exclude= 'true';
-    label='Scoped';
-    iconName = 'scoped';  
-  }
-
-  if (iconName === 'shadow'){
-    icon = <FiberSmartRecordIcon css={iconStyles} />;
-  } else if (iconName === 'code'){
-    icon = <CodeIcon css={iconStyles} />;
-  } else if(iconName === 'scoped'){
-    icon = <BiotechIcon css={iconStyles} />
-  } else{
-    icon = <StyleIcon css={iconStyles} />;
+    case 'name':
+      tooltipText="The name of this web component as it appears in the DOM.";
+        if (!(exclude)){
+          const path = "/docs/client-components/";
+          const clientPage = label.replace("dwc-", "");
+          href = path.concat(clientPage);
+        }
+      icon = <CodeIcon css={iconStyles} />;
+    break;
+    // A "Version" chip    
+    case 'since':
+      tooltipText = "This feature is available for webforJ " + label + " and higher.";
+      exclude= 'true';
+      icon = <AddTaskIcon css={iconStyles} />
+    break;
+    // A "Scoped" chip
+    case 'scoped':
+      tooltipText = "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.";
+      exclude= 'true';
+      label='Scoped';
+      icon = <BiotechIcon css={iconStyles} />
+    break;
+    default:
+      console.warn("Uknown chip type:", chip);
+      icon = <DescriptionIcon css={iconStyles} />;
+      exclude= 'true';
   }
 
   return (

--- a/docs/src/components/DocsTools/JavadocLink.js
+++ b/docs/src/components/DocsTools/JavadocLink.js
@@ -77,7 +77,7 @@ export default function JavadocLink({
         margin-bottom: 1em;
         margin-left: 0.5em;
         float: right;
-        @media (max-width: 500px) {
+        @media (max-width: 1250px) {
           margin-bottom: 1em;
           float: none;
           margin-left: -0.25em;
@@ -101,6 +101,8 @@ export default function JavadocLink({
       background-color: var(--javadoclink-hover-bg);
       color: var(--javadoclink-hover-color);
     }
+    position: relative;
+    top: 0.3rem;
   `;
 
   return (


### PR DESCRIPTION
This PR will close Issue #339 by adding a `since` badge, which helps track when a feature was introduced.

![tooltip](https://github.com/user-attachments/assets/3ea3d610-aee3-47f8-b34c-68a2f699a550)

I also adjusted the vertical alignment for `DocChip`, so the `since` badge can display nicely in an article header for when there are topics about multiple classes or specific concepts: 

https://docs.webforj.com/docs/components/table/styling
![HeaderVersion](https://github.com/user-attachments/assets/8aeebb0b-d8d1-4442-b14c-f42e23ce245c)

This will also also help when documenting new features to already existing components:

https://docs.webforj.com/docs/components/button#adding-icons-to-buttons
![sectioned](https://github.com/user-attachments/assets/a8574760-c724-427a-a34b-b1db69b4e0a1)

## Side Note:
The changes to `JavadocLink` keep that badge vertically aligned with the other badges and prevents overfill into the first paragraph when the badges take up more space, like on [AppNav](https://docs.webforj.com/docs/components/appnav).

