### PR TITLE
Clarify TextArea length counter to include newline characters (\n)

### DIFF
--- a/src/main/java/com/webforj/samples/views/textarea/TextAreaValidationView.java
+++ b/src/main/java/com/webforj/samples/views/textarea/TextAreaValidationView.java
@@ -115,7 +115,7 @@ public class TextAreaValidationView extends Composite<FlexLayout> {
     }
 
     String paragraphSizes = sb.toString();
-    status.setValue("Current Length: " + text.length() +
+    status.setValue("Current Length (including \n): " + text.length() +
         "\nCurrent Line Count: " + paragraphs.size() +
         "\nParagraph Sizes: " + (paragraphSizes.isEmpty() ? "[]" : paragraphSizes));
   }


### PR DESCRIPTION
updated the TextAreaValidationView demo to clarify how character counting works in the TextArea component

closes #319 