### PR TITLE
fix: Declared the width of the bound component in TreeView

### DIFF
--- a/src/main/java/com/webforj/samples/views/tree/TreeView.java
+++ b/src/main/java/com/webforj/samples/views/tree/TreeView.java
@@ -16,7 +16,7 @@ public class TreeView extends Composite<FlexLayout> {
 
   public TreeView() {
     self.setDirection(FlexDirection.COLUMN)
-        .setHeight("100vh")
+        .setSize("min-content", "100vh")
         .setStyle("overflow", "auto");
 
     tree.add(


### PR DESCRIPTION
This PR will close Issue #356.