### PR TITLE
test: Added check to avoid using the word "enhance"

### DIFF
--- a/.github/.styles/webforJ/Avoid.yml
+++ b/.github/.styles/webforJ/Avoid.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "Avoid using '%s'. Focus more on explicitly defining what the feature does to improve 'x'."
+level: warning
+ignorecase: true
+raw:
+  - enhanc(e|ed|es|ing)? (the (\w+|and \w+)?|\w+)?( and \w+)?


### PR DESCRIPTION
## Content

This PR adds a style guide rule to avoid using various forms of "enhance" in the docs, for example:

- enhancing usability
- enhanced user experience
- enhance the responsive and feeling

## Reasoning

These phrases can be generic. The article sections should be more focused on actual behavior of a given feature and why it's able to improve the usability or user experience.

## Note

The word "enhancement" is an exception to this rule, as it is mainly used to talk about the additions to the webforJ framework itself.