### PR TITLE
fix: Made webforJ logo white in dark mode

### DIFF
--- a/src/main/resources/css/applayout/applayout.css
+++ b/src/main/resources/css/applayout/applayout.css
@@ -20,6 +20,10 @@
   border-radius: 10px;
 }
 
+html[data-app-theme="dark"] .drawer__logo img {
+filter: brightness(0) invert(1);
+}
+
 .card {
   padding: var(--dwc-space-m);
   margin: var(--dwc-space-m) auto;


### PR DESCRIPTION
This PR will close Issue #385 by making the webforJ logo white in dark mode.

## Dark Mode
![dark](https://github.com/user-attachments/assets/1bf491de-0a04-4c2f-9a62-43aa6ac30f11)

## Light Mode
![light](https://github.com/user-attachments/assets/211b937d-b85f-4cd5-bdd8-226ac722f61e)
