### PR TITLE
fix: Made non-visible sidebar items visible for DocCardList

### DIFF
--- a/docs/src/css/_sidebar.scss
+++ b/docs/src/css/_sidebar.scss
@@ -3,7 +3,7 @@
     background-color: var(--dwc-surface-3);
   }
 
-  .sidebar--item__hidden {
+  .menu__list-item.sidebar--item__hidden {
     display: none !important;
   }
 


### PR DESCRIPTION
This PR will close Issue #441.

In newer versions of Docusaurus, the `DocCardList` component inherits the CSS class defined in the frontmatter with `sidebar_class_name`. This PR makes it so it only applies the styling if it's also a menu list item. (i.e. hide it from the sidebar, but keep it displayed in the `DocCardList`)