### PR TITLE
Document webforJ servlets config

### DIFF
--- a/docs/docs/configuration/deploying-additional-servlets.md
+++ b/docs/docs/configuration/deploying-additional-servlets.md
@@ -93,10 +93,14 @@ This approach keeps `WebforjServlet` at `/*` and configures custom servlets in `
 ### webforJ.conf configuration {#webforjconf-configuration}
 
 ```hocon
-servlets = [
+servlets: [
   {
-    name = "hello-world"
-    class = "com.example.HelloWorldServlet"
+    class: "com.example.HelloWorldServlet",
+    name: "hello-world",
+    config: {
+      foo: "bar",
+      baz: "bang"
+    }
   }
 ]
 ```
@@ -104,3 +108,4 @@ servlets = [
 With this configuration:
 - `WebforjServlet` handles all requests
 - Requests to `/hello-world` are proxied to `HelloWorldServlet`
+- The optional `config` key provides name/value pairs as initialization parameters for the servlet

--- a/docs/docs/configuration/deploying-additional-servlets.md
+++ b/docs/docs/configuration/deploying-additional-servlets.md
@@ -63,7 +63,7 @@ This property remaps `WebforjServlet` from the default `/*` to `/ui/*`, freeing 
 
 ## Approach 2: `WebforjServlet` proxy configuration {#approach-2-webforjservlet-proxy-configuration}
 
-This approach keeps `WebforjServlet` at `/*` and configures custom servlets in `webforJ.conf`. The `WebforjServlet` intercepts all requests and proxies matching patterns to your custom servlets.
+This approach keeps `WebforjServlet` at `/*` and configures custom servlets in `webforj.conf`. The `WebforjServlet` intercepts all requests and proxies matching patterns to your custom servlets.
 
 ### Standard web.xml configuration {#standard-webxml-configuration}
 


### PR DESCRIPTION
Updated example code and added explanatory bullet to Deploying Additional Servlets article. Based on the issue, I think I have documented this correctly, but please let me know if anything else is needed.

```hocon
servlets: [
  {
    class: "com.example.HelloWorldServlet",
    name: "hello-world",
    config: {
      foo: "bar",
      baz: "bang"
    }
  }
]
```

> The optional `config` key provides name/value pairs as initialization parameters for the servlet

The code is a blend of the existing example and the code that Hyyan provided for this issue, in order to show config parameter and still fit with the existing samples.

Closes #508 