### PR TITLE
feat: Added link to GitHub releases to version badges

### DIFF
--- a/docs/src/components/DocsTools/DocChip.js
+++ b/docs/src/components/DocsTools/DocChip.js
@@ -51,8 +51,8 @@ export default function DocChip( { chip, label, href, exclude, tooltipText, colo
     break;
     // A "Version" chip    
     case 'since':
-      tooltipText = "This feature is available for webforJ " + label + " and higher.";
-      exclude= 'true';
+      tooltipText = `This feature is available for webforJ ${label} and higher.`;
+      href = `https://github.com/webforj/webforj/releases/tag/${label}`;
       icon = <AddTaskIcon css={iconStyles} />
     break;
     // A "Scoped" chip


### PR DESCRIPTION
This PR will close Issue #550 by adding a link to the version badges that'll go to the GitHub webforJ release page for the specified tag.

For example, following badge will now have a link to https://github.com/webforj/webforj/releases/tag/23.06

<img width="276" height="75" alt="image" src="https://github.com/user-attachments/assets/28b4cb68-241c-45db-aaec-098ecdf40e88" />