### PR TITLE
fix: Added validation for max rows in `ComboBoxMaxRowView`

### DIFF
--- a/src/main/java/com/webforj/samples/views/lists/combobox/ComboBoxMaxRowView.java
+++ b/src/main/java/com/webforj/samples/views/lists/combobox/ComboBoxMaxRowView.java
@@ -14,19 +14,26 @@ import com.webforj.router.annotation.Route;
 @FrameTitle("ComboBox Max Row")
 public class ComboBoxMaxRowView extends Composite<FlexLayout> {
 
-  ComboBox demoBox = new ComboBox("States");
+  ComboBox comboBox = new ComboBox("States");
   NumberField numberField = new NumberField("Number of Rows");
   Button select = new Button("Apply", ButtonTheme.PRIMARY);
 
   public ComboBoxMaxRowView() {
     getBoundComponent().setDirection(FlexDirection.COLUMN).setMargin("20px 0 0 20px").setSpacing("20px").setWidth(200);
-    getBoundComponent().add(demoBox, numberField, select);
-    numberField.setInvalidMessage("Number of rows cannot be empty.");
+    getBoundComponent().add(comboBox, numberField, select);
+
+    numberField.setStep(1.0)
+        .setMax(50.0)
+        .setMin(0.0)
+        .setRequired(true)
+        .setValue((double) comboBox.getMaxRowCount());
+
+    numberField.onValueChange(e -> {
+      select.setEnabled(!numberField.isInvalid());
+    });
+
     select.onClick(e -> {
-      if (!numberField.getText().isBlank())
-        demoBox.setMaxRowCount(Integer.valueOf(numberField.getText()));
-      else
-        numberField.setInvalid(true);
+      comboBox.setMaxRowCount(numberField.getValue().intValue());
     });
 
     String[] states = { "Alabama", "Alaska", "Arizona", "Arkansas", "California", "Colorado", "Connecticut", "Delaware",
@@ -35,6 +42,6 @@ public class ComboBoxMaxRowView extends Composite<FlexLayout> {
         "Nevada", "New Hampshire", "New Jersey", "New Mexico", "New York", "North Carolina", "North Dakota", "Ohio",
         "Oklahoma", "Oregon", "Pennsylvania", "Rhode Island", "South Carolina", "South Dakota", "Tennessee", "Texas",
         "Utah", "Vermont", "Virginia", "Washington", "West Virginia", "Wisconsin", "Wyoming" };
-    demoBox.insert(states);
+    comboBox.insert(states);
   }
 }


### PR DESCRIPTION
This PR will close Issues #566 and #567.

The [Apply] button will only be enabled when valid, between 0 and 50. It also excepts scientific notations that are within the acceptable range, like 2e1 (20).