### PR TITLE
fix: keep AskMenu aligned with title by preventing button wrapping

### DIFF
--- a/docs/src/css/custom.scss
+++ b/docs/src/css/custom.scss
@@ -127,3 +127,31 @@ blockquote {
     );
   }
 }
+
+[class^="headingWrapper_"], [class*=" headingWrapper_"] {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: nowrap !important;  
+}
+
+[class^="headingWrapper_"] h1, [class*=" headingWrapper_"] h1 {
+  flex: 1 1 0;                    
+  min-width: 0;                 
+  white-space: normal;          
+  overflow-wrap: anywhere;      
+  margin: 0;
+}
+
+[class^="headingWrapper_"] [class^="askMenu_"],
+[class*=" headingWrapper_"] [class^="askMenu_"] {
+  flex: 0 0 auto;                
+  display: inline-flex;   
+  max-width: max-content;
+  white-space: nowrap;
+}
+
+[class^="headingWrapper_"] [class^="askMenu_"] * {
+  white-space: nowrap;
+  min-width: 0;
+}


### PR DESCRIPTION
- Updated global CSS to enforce flex layout for doc headers
- Allowed h1 titles to wrap while keeping AskMenu pinned on the right
- Prevents GPT button from dropping below the title on long headings

closes #469 