### PR TITLE
docs: Add webforj.mime.extensions configuration documentation

### DIFF
--- a/docs/docs/configuration/properties.md
+++ b/docs/docs/configuration/properties.md
@@ -75,37 +75,3 @@ The `web.xml` file is an essential configuration file for Java web apps, and in 
 
 <!-- ## Configuring `blsclient.conf` -->
 
-## Custom MIME Type Mappings {#mime-type-mappings}
-
-webforJ automatically detects MIME types for static files served from the `resources/static` directory. The `webforj.mime.extensions` property allows you to override these defaults or define MIME types for custom file extensions.
-
-The configuration accepts a map where the key is the file extension (without the dot) and the value is the MIME type string.
-
-Example `webforj.conf` configuration:
-
-```ini
-webforj.mime.extensions = {
-    "txt": "text/plain",
-    "foo": "foo/bar",
-    "md": "text/markdown"
-}
-```
-
-Spring Boot `application.properties` configuration:
-
-```properties
-webforj.mime.extensions.txt=text/plain
-webforj.mime.extensions.foo=foo/bar
-webforj.mime.extensions.md=text/markdown
-```
-
-Spring Boot `application.yml` configuration:
-
-```yaml
-webforj:
-  mime:
-    extensions:
-      txt: text/plain
-      foo: foo/bar
-      md: text/markdown
-```

--- a/docs/docs/integrations/spring/spring-boot.md
+++ b/docs/docs/integrations/spring/spring-boot.md
@@ -1,7 +1,6 @@
 ---
 title: Spring Boot
 sidebar_position: 10
-sidebar_class_name: updated-content
 ---
 
 Spring Boot is a popular choice for building Java apps, providing dependency injection, auto-configuration, and an embedded server model. When using Spring Boot with webforJ, you can inject services, repositories, and other Spring-managed beans directly into your UI components through constructor injection.
@@ -230,7 +229,6 @@ The following webforJ `application.properties` settings are specific to Spring:
 |----------|------|-------------|--------|
 | **`webforj.servletMapping`** | String | URL mapping pattern for the webforJ servlet. | `/*` |
 | **`webforj.excludeUrls`** | List | URL patterns that shouldn't be handled by webforJ when mapped to root. When webforJ is mapped to the root context (`/*`), these URL patterns will be excluded from webforJ handling and can be handled by Spring MVC controllers instead. This allows REST endpoints and other Spring MVC mappings to coexist with webforJ routes. | `[]` |
-| **`webforj.mime.extensions`** | Map | Custom MIME type mappings for file extensions in static files. Map file extensions (without dot) to MIME types. | `{}` |
 
 ### Configuration differences {#configuration-differences}
 


### PR DESCRIPTION
Document webforj.mime.extensions property for custom MIME type mappings
in static files. Added to property configuration and Spring integration docs.

closes #575 