### PR TITLE
fix: Corrected reviewdog workflow syntax

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,7 +1,8 @@
 name: reviewdog
-on: [pull_request]
-  paths-ignore:
-    - 'docs/blog/**'
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/blog/**'
 jobs:
   vale:
     name: runner / vale


### PR DESCRIPTION
This issue will close Issues #649 and #447. `paths-ignore` is now properly nested within `on`.

Reference: GitHub's Docs for [Workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore)