### PR TITLE
test: Exclude webforJ and other capitalization rules for header anchors

### DIFF
--- a/.github/.styles/webforJ/Capitalization.yml
+++ b/.github/.styles/webforJ/Capitalization.yml
@@ -1,9 +1,9 @@
 extends: substitution
 message: "Use '%s' instead of '%s'."
 level: warning
-ignorecase: false
+ignorecase: true
 action:
   name: replace
 swap:
-  "(?i)(?<!/)webforj": webforJ
-  "(?i)(?<!/)startforj": startforJ
+  '(?<![\#-/])webforj(?![-/])': webforJ
+  '(?<![\#-/])startforj(?![-/])': startforJ

--- a/.vale.ini
+++ b/.vale.ini
@@ -17,6 +17,7 @@ Google.Passive = NO
 Google.Will = NO
 Google.Parens = NO
 Google.Latin = NO
+BlockIgnores = "{#.*?}"
 
 [formats]
 mdx = md


### PR DESCRIPTION
This PR will close Issue #664

- Restricted when the webforJ capitalization style is used, so id names, file paths, and URLs wont flag it.
- Set Vale to ignore anchor blocks (`{#...}`). This prevents the `Google.Headings` style flagging anchors that don't match the casing within [`accept.txt`](https://github.com/webforj/webforj-documentation/blob/main/.github/.styles/config/vocabularies/webforj/accept.txt)
   - For example, `{#cors-configuration}` would flag the rule because CORS is in `accept.txt`:
   
   <img width="918" height="77" alt="image" src="https://github.com/user-attachments/assets/4073106a-9025-48de-a6b0-aed211f0da52" />
   With this PR, the above mentioned example and many other anchor tags will no longer throw a flag.
 