### PR TITLE
chore: Remove deprecated broken markdown links config

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -9,7 +9,6 @@ const config = {
   tagline: 'webforJ is a robust and flexible web framework that allows you to easily create a modern and engaging user interface using Java.',
   url: 'https://docs.webforj.com/',
   baseUrl: '/',
-  onBrokenLinks: 'throw',
   favicon: 'https://docs.webforj.com/icons/icon.png',
   organizationName: 'webforj',
   projectName: 'webforj-docs',
@@ -139,6 +138,10 @@ const config = {
   themes: ['@docusaurus/theme-mermaid'],
   markdown: {
     mermaid: true,
+     hooks: {
+      onBrokenMarkdownLinks: 'throw',
+      onBrokenMarkdownImages: 'throw',
+    },
   },
   themeConfig: {
     algolia: {


### PR DESCRIPTION
This PR will close Issue #618.

This removes the deprecated `onBrokenMarkdownLinks` config option, and since the project is using the default for [`siteConfig.markdown.hooks.onBrokenMarkdownLinks`](https://docusaurus.io/docs/api/docusaurus-config#hooks.onBrokenMarkdownLinks), it doesn't need to be explicitly configured.