### PR TITLE
chore: fix broken links in Webswing blog post.

### DIFF
--- a/docs/blog/2026-01-22-webswing/index.md
+++ b/docs/blog/2026-01-22-webswing/index.md
@@ -11,7 +11,7 @@ hide_table_of_contents: false
 ![cover image](https://cdn.webforj.com/webforj-documentation/blogs/webswing/blog_webswing_cover.png)
 
 If you're lucky enough to be writing a new web app from scratch, it's easy to see how webforJ could benefit you. 
-webforJ simplifies your deployment and provides a [UI framework of components](../../docs/components/overview) that conforms to web standards and user expectations, all while you enjoy the familiar experience of coding in Java and integrating with the Java ecosystem. 
+webforJ simplifies your deployment and provides a [UI framework of components](/docs/components/overview) that conforms to web standards and user expectations, all while you enjoy the familiar experience of coding in Java and integrating with the Java ecosystem. 
 But what if you already have a Java desktop app, and you need to deploy it to the web? 
 Do you have to rewrite the whole thing, or can you **modernize your legacy Java code into a fully functional web app**?
 Look no further, because webforJ has the answer: deploy your existing Java app to the web quickly with Webswing, and gradually modernize it into a true web app with webforJ.
@@ -52,24 +52,24 @@ When you use Webswing with webforJ, in addition to bringing your app immediately
 
 webforJ integrates with Webswing through the `WebswingConnector` component, which embeds a Webswing server in your webforJ app.
 This component manages communication between your app and the Webswing server through commands and events, giving you the ability to both control and respond to the embedded app.
-See the Webswing integration [Communication](../../docs/integrations/webswing/communication) page for technical details on how to coordinate between webforJ and Webswing.
+See the Webswing integration [Communication](/docs/integrations/webswing/communication) page for technical details on how to coordinate between webforJ and Webswing.
 
 ## Incremental modernization
 
 Once you deploy your app with the `WebswingConnector` component in webforJ, you can start modernizing it incrementally, while maintaining full functionality. 
-See the [modernization tutorial](../../docs/integrations/webswing/tutorial) for more information on this process. 
+See the [modernization tutorial](/docs/integrations/webswing/tutorial) for more information on this process. 
 In short, it's easy to keep everything working while you convert portions of your app to webforJ components.
 Every dialog or menu that you implement in webforJ will improve your users' experience and convey that your app is at home on the web. 
 Users will feel more comfortable, and you avoid the higher risk of all-or-nothing rewrites, with the assurance that your app is on its way to being fully modernized.
 
 With Webswing and webforJ, you have no reason to stay locked into the desktop environment! 
 Your app wants to join the rest of its peers in the browser, and you can bring it there today. 
-[Download Webswing](https://www.webswing.org/downloads), [get started with webforJ](../../docs/introduction/getting-started), [modernize your app](../../docs/integrations/webswing/tutorial), and set yourself up for success.
+[Download Webswing](https://www.webswing.org/downloads), [get started with webforJ](/docs/introduction/getting-started), [modernize your app](/docs/integrations/webswing/tutorial), and set yourself up for success.
 
 ## See also
 
-- [Webswing and webforJ modernization tutorial](../../docs/integrations/webswing/tutorial)
-- [Webswing and webforJ integration setup](../../docs/integrations/webswing/setup)
-- [Webswing and webforJ communication](../../docs/integrations/webswing/communication)
+- [Webswing and webforJ modernization tutorial](/docs/integrations/webswing/tutorial)
+- [Webswing and webforJ integration setup](/docs/integrations/webswing/setup)
+- [Webswing and webforJ communication](/docs/integrations/webswing/communication)
 - [Webswing.org](https://www.webswing.org/)
 - [Webswing integration demo ](https://webswing.webforj.com/)


### PR DESCRIPTION
The Webswing blog post used relative link paths (`../../docs/` instead of `/docs/`) which breaks the translated pages. This PR fixes the link formats.