### PR TITLE
chore: Replaced inline text with the `since` DocChip

### DIFF
--- a/docs/docs/routing/navigation-lifecycle/observers.md
+++ b/docs/docs/routing/navigation-lifecycle/observers.md
@@ -11,7 +11,7 @@ Observers allow components to react to lifecycle events by implementing interfac
 - **`DidEnterObserver`**: Ideal for handling actions after the component has been attached, such as rendering data or triggering animations.
 - **`WillLeaveObserver`**: Provides a way to manage logic before a user leaves a route, such as checking for unsaved changes.
 - **`DidLeaveObserver`**: Used for cleanup actions or other tasks that should run after a component is detached from the DOM.
-- <DocChip chip='since' label='25.03' />**`ActivateObserver`**: Triggered when a cached component is reactivated, such as when navigating to the same route with different parameters.
+- **`ActivateObserver`**: <DocChip chip='since' label='25.03' /> Triggered when a cached component is reactivated, such as when navigating to the same route with different parameters.
 
 ## Example: authentication with `WillEnterObserver` {#example-authentication-with-willenterobserver}
 


### PR DESCRIPTION
This PR adds the `since` badge where appropriate on the [Lifecycle Observers](https://docs.webforj.com/docs/routing/navigation-lifecycle/observers) article  

### Before
<img width="772" height="352" alt="before1" src="https://github.com/user-attachments/assets/e28b1b38-6a2f-420c-a16c-3888c68e0a81" />
<img width="767" height="212" alt="before2" src="https://github.com/user-attachments/assets/4381935c-da1d-4381-ab1c-b43784a234d8" />

### After
<img width="772" height="373" alt="after1" src="https://github.com/user-attachments/assets/a52a520f-b165-47cb-a3b8-f18cbd3fb347" />
<img width="757" height="117" alt="after2" src="https://github.com/user-attachments/assets/f9b9d679-b3be-4da9-82a3-519065d8a0af" />