### PR TITLE
chore: Added a border to the DocChip component

### DIFF
--- a/docs/src/components/DocsTools/DocChip.js
+++ b/docs/src/components/DocsTools/DocChip.js
@@ -16,13 +16,15 @@ export default function DocChip( { chip, label, href, exclude, tooltipText, colo
     margin-right: 0.5em;
     margin-bottom: 1em;
     background-color: var(--chip-background);
+    border: 1px solid var(--dwc-color-primary-85);
     color: var(--chip-text);
     position: relative;
     z-index: 0;
     top: 0.3rem;
-    :hover{
+    :hover,:focus {
       color: inherit;
       background-color: var(--chip-background-hover);
+      border: 1px solid var(--dwc-color-primary-55);
     }
   `;
 


### PR DESCRIPTION
This PR will close Issue #732.

The badges are the same size, however, because the badge color doesn't contrast with the gray rows in a table, it gives the illusion that it's smaller.
<img width="422" height="209" alt="badge_before1" src="https://github.com/user-attachments/assets/0c87887f-77a8-4332-bd81-feb565b1cf5f" />
<img width="483" height="221" alt="badge_before2" src="https://github.com/user-attachments/assets/18a9468c-f858-4b90-b062-c3b5c060db37" />

This PR fixes the issue by adding a border color:
<img width="429" height="251" alt="badge_after" src="https://github.com/user-attachments/assets/8f9903c7-f981-4866-a91a-64fae2e3d293" />