### PR TITLE
chore: Made Columns only resizeable by flex values

### DIFF
--- a/src/main/java/com/webforj/samples/views/table/TableColumnFlexSizingView.java
+++ b/src/main/java/com/webforj/samples/views/table/TableColumnFlexSizingView.java
@@ -101,30 +101,26 @@ public class TableColumnFlexSizingView extends Composite<FlexLayout> {
     table.setStriped(true);
 
     table.addColumn("Number", MusicRecord::getNumber)
-        .setWidth(80f)
-        .setResizable(false);
+        .setWidth(80f);
 
     titleColumn = table.addColumn("Title", MusicRecord::getTitle)
         .setFlex(2f)
-        .setMinWidth(120f)
-        .setResizable(true);
+        .setMinWidth(120f);
 
     artistColumn = table.addColumn("Artist", MusicRecord::getArtist)
         .setFlex(1.5f)
-        .setMinWidth(100f)
-        .setResizable(true);
+        .setMinWidth(100f);
 
     genreColumn = table.addColumn("Genre", MusicRecord::getMusicType)
         .setFlex(1f)
-        .setMinWidth(80f)
-        .setResizable(true);
+        .setMinWidth(80f);
 
     table.addColumn("Cost", record -> String.format("$%.2f", record.getCost()))
         .setWidth(80f)
-        .setAlignment(Column.Alignment.RIGHT)
-        .setResizable(false);
+        .setAlignment(Column.Alignment.RIGHT);
 
     table.setRepository(Service.getMusicRecords());
+    table.setColumnsToResizable(false);
 
     return table;
   }


### PR DESCRIPTION
This PR will close Issue #802.

Because width and flex properties are mutually exclusive, I've removed the ability of manually resizing columns via dragging the edges of the columns.

Now the only way to change the sizing is using the numberfields and buttons to change the flex values.