### PR TITLE
chore: For an undeclared title in `TableWrapper`, it uses the nearest header

### DIFF
--- a/docs/src/components/DocsTools/ComponentArchetype.js
+++ b/docs/src/components/DocsTools/ComponentArchetype.js
@@ -85,7 +85,7 @@ export default function ComponentArchetype({ project, flavor = "webforj" }) {
         </CodeBlock>
       </TabItem>
     </Tabs>
-    <TableWrapper>
+    <TableWrapper title="Maven properties">
       <thead>
         <th>{translate({
           id: 'component.archetype.table.argument',

--- a/docs/src/components/DocsTools/TableWrapper.js
+++ b/docs/src/components/DocsTools/TableWrapper.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -11,6 +11,9 @@ import Box from '@mui/material/Box';
 
 export default function TableWrapper({ children, title, ...props }) {
     const [open, setOpen] = useState(false);
+    const [resolvedTitle, setResolvedTitle] = useState(title);
+
+    const tableRef = useRef(null);
 
     const handleClickOpen = () => {
         setOpen(true);
@@ -35,8 +38,20 @@ export default function TableWrapper({ children, title, ...props }) {
         }
     };
 
+    useEffect(() => {
+        if (title) return;
+        let prev = tableRef.current?.previousElementSibling;
+        while (prev) {
+            if (prev.tagName === "H2" || prev.tagName === "H3") {
+                setResolvedTitle(prev.textContent);
+                break;
+            }
+            prev = prev.previousElementSibling;
+        }
+    }, [title]);
+
     return (
-        <div className="table-wrapper" style={{ position: 'relative', marginBottom: '2rem', maxWidth: 'fit-content' }}>
+        <div className="table-wrapper" ref={tableRef} style={{ position: 'relative', marginBottom: '2rem', maxWidth: 'fit-content' }}>
             <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
                 <IconButton
                     onClick={handleClickOpen}
@@ -93,7 +108,7 @@ export default function TableWrapper({ children, title, ...props }) {
                     }}
                 >
                     <h2 style={{ margin: 0, color: 'var(--ifm-font-color-base)' }}>
-                        {title || ''}
+                        {resolvedTitle || ""}
                     </h2>
                     <Tooltip title="Close window">
                         <IconButton


### PR DESCRIPTION
When a table doesn't have a declared title, it'll use the nearest header.

ie, the following table in `debouncing.md` will make the TableWrapper's title "Event level debouncing vs Debouncer" without having to explicitly set it. 

```
## Event level debouncing vs `Debouncer` {#event-level-debouncing-vs-debouncer}

webforJ provides two approaches to debouncing:

| Feature | `Debouncer` | `ElementEventOptions.setDebounce()` |
|---------|-------------|-------------------------------------|
| Scope | Any action | Element events only |
| Location | Server-side | Client-side |
| Unit | Seconds (float) | Milliseconds (int) |
| Flexibility | Full control with cancel/flush | Automatic with event |
```