### PR TITLE
fix: wrap localhost URLs in markdown link syntax

### DIFF
--- a/docs/docs/introduction/tutorial/creating-a-basic-app.md
+++ b/docs/docs/introduction/tutorial/creating-a-basic-app.md
@@ -25,7 +25,7 @@ As you develop your app, you can use [1-creating-a-basic-app](https://github.com
     mvn
     ```
 
-Running the app automatically opens a new browser at http://localhost:8080.
+Running the app automatically opens a new browser at `http://localhost:8080`.
 
 ## The entry point {#entry-point}
 

--- a/docs/docs/introduction/tutorial/integrating-into-applayout.md
+++ b/docs/docs/introduction/tutorial/integrating-into-applayout.md
@@ -18,7 +18,7 @@ As you develop your app, you can use [6-integrating-an-app-layout](https://githu
     mvn
     ```
 
-Running the app automatically opens a new browser at http://localhost:8080.
+Running the app automatically opens a new browser at `http://localhost:8080`.
 
 ## Purpose of the app Layout {#purpose-of-the-app-layout}
 

--- a/docs/docs/introduction/tutorial/observers-and-route-parameters.md
+++ b/docs/docs/introduction/tutorial/observers-and-route-parameters.md
@@ -29,7 +29,7 @@ As you develop your app, you can use [4-observers-and-route-parameters](https://
     mvn
     ```
 
-Running the app automatically opens a new browser at http://localhost:8080.
+Running the app automatically opens a new browser at `http://localhost:8080`.
 
 ## Using the customer's `id` {#using-the-customers-id}
 
@@ -47,15 +47,15 @@ In this step, you’ll make changes to `FormView` so it uses an `id` as an initi
 
 ## Adding a route pattern to `FormView` {#adding-a-route-pattern}
 
-In the previous step, setting the route in `FormView` to `@Route(customer)` maps the class locally to [http://localhost:8080/**customer**](http://localhost:8080/customer). Adding a route pattern lets you add an `id` as an initial parameter to `FormView`.
+In the previous step, setting the route in `FormView` to `@Route(customer)` maps the class locally to `http://localhost:8080/customer`. Adding a route pattern lets you add an `id` as an initial parameter to `FormView`.
 
 A [Route Pattern](/docs/routing/route-patterns) lets you add a parameter in the URL, make it optional, and set constraints on valid patterns. Using the `@Route` annotation, here’s what makes `id` an optional route parameter for `FormView`:
 
-- **`/:id`** gives the route a named parameter of `id`, so going to [http://localhost:8080/**customer/6**](http://localhost:8080/customer/6) loads `FormView` with an `id` parameter of `6`.
+- **`/:id`** gives the route a named parameter of `id`, so going to `http://localhost:8080/customer/6` loads `FormView` with an `id` parameter of `6`.
 
 - **`?`** makes the `id` parameter optional. By default, parameters are required, but making the `id` optional lets you use `FormView` for adding new customers that don’t have an `id` yet.
 
-- **`<[0-9]+>`** constrains `id` to be a positive number. In angle brackets, `<>`, you can add a constraint as a regular expression to the parameter. If the `id` doesn’t match the constraint, e.g., [http://localhost:8080/customer/**john-smith**](http://localhost:8080/customer/john-smith), it sends the user to a 404 page.
+- **`<[0-9]+>`** constrains `id` to be a positive number. In angle brackets, `<>`, you can add a constraint as a regular expression to the parameter. If the `id` doesn’t match the constraint, e.g., `http://localhost:8080/customer/john-smith`, it sends the user to a 404 page.
 
 To add the optional route parameter to `FormView`, change the `@Route` annotation to this:
 
@@ -67,7 +67,7 @@ To add the optional route parameter to `FormView`, change the `@Route` annotatio
 
 `FormView` now accepts an optional `id` parameter and only loads if the `id` is a whole positive number.
 
-However, `FormView` can still load when a user manually enters a URL for a non-existent customer, like [http://localhost:8080/customer/**5000**](http://localhost:8080/customer/5000). Adding a lifecycle observer before entering `FormView` lets your app determine how to handle the incoming `id` value.
+However, `FormView` can still load when a user manually enters a URL for a non-existent customer, like `http://localhost:8080/customer/5000`. Adding a lifecycle observer before entering `FormView` lets your app determine how to handle the incoming `id` value.
 
 ### Conditional routing {#conditional-routing}
 

--- a/docs/docs/introduction/tutorial/project-setup.md
+++ b/docs/docs/introduction/tutorial/project-setup.md
@@ -120,5 +120,5 @@ To see the app in action as you progress through the tutorial:
     ```
 
 <!-- vale Google.WordList = NO -->
-Running the app automatically opens a new browser at http://localhost:8080.
+Running the app automatically opens a new browser at `http://localhost:8080`.
 <!-- vale Google.WordList = YES -->

--- a/docs/docs/introduction/tutorial/routing-and-composites.md
+++ b/docs/docs/introduction/tutorial/routing-and-composites.md
@@ -27,7 +27,7 @@ As you develop your app, you can use [3-routing-and-composites](https://github.c
     mvn
     ```
 
-Running the app automatically opens a new browser at [http://localhost:8080](http://localhost:8080).
+Running the app automatically opens a new browser at `http://localhost:8080`.
 
 ## Routable apps {#routable-apps}
 
@@ -83,7 +83,7 @@ To keep the app's two functions separate, your app needs to map the UIs to two u
 
 ### Mapping URLs to components {#mapping-urls-to-components}
 
-Your app is routable and knows to look for two `View` routes, `MainView` and `FormView`, but it doesn't have a specific URL to load them at. Using the `@Route` annotation on a view class, you can tell webforJ where to load it based on a given URL segment. For example, using `@Route("about")` in a view locally maps the class to [http://localhost:8080/**about**](http://localhost:8080/about).
+Your app is routable and knows to look for two `View` routes, `MainView` and `FormView`, but it doesn't have a specific URL to load them at. Using the `@Route` annotation on a view class, you can tell webforJ where to load it based on a given URL segment. For example, using `@Route("about")` in a view locally maps the class to `http://localhost:8080/about`.
 
 As the name implies, `MainView` is the class you want to initially load when the app runs. To achieve this, add a `@Route` annotation that maps `MainView` to the root URL of your app:
 
@@ -97,7 +97,7 @@ public class MainView {
 }
 ```
 
-For the `FormView`, map the view so it loads when a user goes to [http://localhost:8080/**customer**](http://localhost:8080/customer):
+For the `FormView`, map the view so it loads when a user goes to `http://localhost:8080/customer`:
 
 ```java title="FormView.java" {1}
 @Route("customer")

--- a/docs/docs/introduction/tutorial/validating-and-binding-data.md
+++ b/docs/docs/introduction/tutorial/validating-and-binding-data.md
@@ -29,7 +29,7 @@ As you develop your app, you can use [5-validating-and-binding-data](https://git
     mvn
     ```
 
-Running the app automatically opens a new browser at [http://localhost:8080](http://localhost:8080).
+Running the app automatically opens a new browser at `http://localhost:8080`.
 
 ## Defining validation rules {#defining-validation-rules}
 

--- a/docs/docs/introduction/tutorial/working-with-data.md
+++ b/docs/docs/introduction/tutorial/working-with-data.md
@@ -30,7 +30,7 @@ As you develop your app, you can use [2-working-with-data](https://github.com/we
     mvn
     ```
 
-Running the app automatically opens a new browser at [http://localhost:8080](http://localhost:8080).
+Running the app automatically opens a new browser at `http://localhost:8080`.
 
 ## Dependencies and configurations {#dependencies-and-configurations}
 


### PR DESCRIPTION
Closes 809 (after we re-run the Update Translations job)

The [Update Translations](https://github.com/webforj/webforj-documentation/actions/workflows/translations.yml) job has been failing since March 10, which seems to be the cause of the failed builds that Eric was trying to fix with [fix: resolve broken i18n links to html-elements page](https://github.com/webforj/webforj-documentation/pull/819). 

The failure seems to have been caused by the updated tutorial. The output references the files observers-and-route-parameters.md, project-setup.md, and working-with-data.md. It says it can't parse the URL http://localhost:8080 . In all of these pages, that URL shows up on its own, outside of the Markdown link syntax, and not in code backticks:

`Running the app automatically opens a new browser at http://localhost:8080.`

I think that wrapping these URLs in Markdown link syntax will fix this problem.