### PR TITLE
feat: make DocChip translatable

### DIFF
--- a/docs/i18n/de/code.json
+++ b/docs/i18n/de/code.json
@@ -395,7 +395,7 @@
   },
   "theme.SearchPage.algoliaLabel": {
     "message": "Suche mit Algolia",
-    "description": "The ARIA label for Algolia mention"
+    "description": "The description label for Algolia mention"
   },
   "theme.SearchPage.noResultsText": {
     "message": "Keine Ergebnisse gefunden",
@@ -423,15 +423,15 @@
   },
   "theme.SearchModal.startScreen.noRecentSearchesText": {
     "message": "Keine aktuellen Suchanfragen",
-    "description": "The text when no recent searches"
+    "description": "The text when there are no recent searches"
   },
   "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
     "message": "Diese Suche speichern",
-    "description": "The label for save recent search button"
+    "description": "The title for save recent search button"
   },
   "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
     "message": "Diesen Suchvorgang aus der Historie entfernen",
-    "description": "The label for remove recent search button"
+    "description": "The title for remove recent search button"
   },
   "theme.SearchModal.startScreen.favoriteSearchesTitle": {
     "message": "Favorit",
@@ -439,63 +439,63 @@
   },
   "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
     "message": "Dieses Suchergebnis aus Favoriten entfernen",
-    "description": "The label for remove favorite search button"
+    "description": "The title for remove favorite search button"
   },
   "theme.SearchModal.errorScreen.titleText": {
     "message": "Ergebnisse können nicht abgerufen werden",
-    "description": "The title for error screen of search modal"
+    "description": "The title for error screen"
   },
   "theme.SearchModal.errorScreen.helpText": {
     "message": "Überprüfen Sie Ihre Netzwerkverbindung.",
-    "description": "The help text for error screen of search modal"
+    "description": "The help text for error screen"
   },
   "theme.SearchModal.footer.selectText": {
     "message": "auswählen",
-    "description": "The explanatory text of the action for the enter key"
+    "description": "The select text for footer"
   },
   "theme.SearchModal.footer.selectKeyAriaLabel": {
     "message": "Eingabetaste",
-    "description": "The ARIA label for the Enter key button that makes the selection"
+    "description": "The ARIA label for select key in footer"
   },
   "theme.SearchModal.footer.navigateText": {
     "message": "navigieren",
-    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+    "description": "The navigate text for footer"
   },
   "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
     "message": "Pfeil nach oben",
-    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+    "description": "The ARIA label for navigate up key in footer"
   },
   "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
     "message": "Pfeil nach unten",
-    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+    "description": "The ARIA label for navigate down key in footer"
   },
   "theme.SearchModal.footer.closeText": {
     "message": "schließen",
-    "description": "The explanatory text of the action for Escape key"
+    "description": "The close text for footer"
   },
   "theme.SearchModal.footer.closeKeyAriaLabel": {
     "message": "Escape-Taste",
-    "description": "The ARIA label for the Escape key button that close the modal"
+    "description": "The ARIA label for close key in footer"
   },
   "theme.SearchModal.footer.searchByText": {
     "message": "Suche nach",
-    "description": "The text explain that the search is making by Algolia"
+    "description": "The 'Powered by' text for footer"
   },
   "theme.SearchModal.noResultsScreen.noResultsText": {
     "message": "Keine Ergebnisse für",
-    "description": "The text explains that there are no results for the following search"
+    "description": "The text when there are no results"
   },
   "theme.SearchModal.noResultsScreen.suggestedQueryText": {
     "message": "Versuchen Sie zu suchen nach",
-    "description": "The text for the suggested query when no results are found for the following search"
+    "description": "The text for suggested query"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
     "message": "Glauben Sie, dass diese Abfrage Ergebnisse liefern sollte?",
-    "description": "The text for the question where the user thinks there are missing results"
+    "description": "The text for reporting missing results"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
     "message": "Lass es uns wissen.",
-    "description": "The text for the link to report missing results"
+    "description": "The link text for reporting missing results"
   },
   "theme.SearchModal.placeholder": {
     "message": "Dokumente durchsuchen",
@@ -712,5 +712,161 @@
   "componentArchetype.finalInstruction": {
     "message": "Nach Ausführung des Befehls wird Maven die Projektdateien generieren, die zum Ausführen des Projekts erforderlich sind.",
     "description": "Final instruction about Maven generating project files"
+  },
+  "running-the-app": {
+    "message": "Running the app",
+    "description": "Running the app title"
+  },
+  "component.archetype.running.app.desc": {
+    "message": "Before running your app, install the {prerequisites} if you haven't yet. Then, navigate to the project's root directory and run the following command:",
+    "description": "Running the app description"
+  },
+  "component.archetype.mvn.shorthand.title": {
+    "message": "Full maven command",
+    "description": "Full maven command note title"
+  },
+  "component.archetype.mvn.command.desc": {
+    "message": "The shorthand mvn command works because the archetype's POM file includes a {default} configuration that automatically runs the appropriate goal for your project type. If your project doesn't have {default}, run the following:",
+    "description": "Full maven command note description"
+  },
+  "component.archetype.browser.desc": {
+    "message": "Once the server is running, open your browser and go to {localhost} to view the app.",
+    "description": "running in the browser text"
+  },
+  "chip.tooltipText.shadow": {
+    "message": "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.",
+    "description": "Hover text for components that render with a shadow DOM (document object model)"
+  },
+  "chip.label.shadow": {
+    "message": "Shadow",
+    "description": "Label to indicate a shadow DOM (document object model)"
+  },
+  "chip.tooltipText.name": {
+    "message": "This feature is available for webforJ {version} and higher.",
+    "description": "Hover text to explain what version of webforJ you need to use the feature."
+  },
+  "chip.tooltipText.webforJ.version.snapshot": {
+    "message": "This feature will be available in a future release.",
+    "description": "Hover text to explain this feature is only available in a snapshot version of webforJ."
+  },
+  "chip.tooltipText.scoped": {
+    "message": "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.",
+    "description": "Hover text to explain this component is scoped, an alternative approach to the shadow DOM (document object model)."
+  },
+  "chip.label.scoped": {
+    "message": "Scoped",
+    "description": "Label to show this component uses scoped components."
+  },
+  "chip.tooltipText.experimental": {
+    "message": "This is an experimental feature and may change in future releases.",
+    "description": "Hover text to explain this feature is experimental and subject to change."
+  },
+  "chip.label.experimental": {
+    "message": "Experimental",
+    "description": "Label to show this component is experimental."
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.SearchModal.searchBox.placeholderText": {
+    "message": "Dokumentation durchsuchen",
+    "description": "The placeholder text for the main search input field"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAi": {
+    "message": "Weitere Frage stellen...",
+    "description": "The placeholder text when in AI question mode"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAiStreaming": {
+    "message": "Antwortet...",
+    "description": "The placeholder text for search box when AI is streaming an answer"
+  },
+  "theme.SearchModal.searchBox.enterKeyHint": {
+    "message": "suchen",
+    "description": "The hint for the search box enter key text"
+  },
+  "theme.SearchModal.searchBox.enterKeyHintAskAi": {
+    "message": "eingeben",
+    "description": "The hint for the Ask AI search box enter key text"
+  },
+  "theme.SearchModal.searchBox.searchInputLabel": {
+    "message": "Suchen",
+    "description": "The ARIA label for search input"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
+    "message": "Zurück zur Stichwortsuche",
+    "description": "The text for back to keyword search button"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonAriaLabel": {
+    "message": "Zurück zur Stichwortsuche",
+    "description": "The ARIA label for back to keyword search button"
+  },
+  "theme.SearchModal.startScreen.recentConversationsTitle": {
+    "message": "Letzte Gespräche",
+    "description": "The title for recent conversations"
+  },
+  "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
+    "message": "Dieses Gespräch aus dem Verlauf entfernen",
+    "description": "The title for remove recent conversation button"
+  },
+  "theme.SearchModal.resultsScreen.askAiPlaceholder": {
+    "message": "KI fragen: ",
+    "description": "The placeholder text for Ask AI input"
+  },
+  "theme.SearchModal.askAiScreen.disclaimerText": {
+    "message": "Antworten werden von KI generiert und können Fehler enthalten. Bitte überprüfen Sie die Antworten.",
+    "description": "The disclaimer text for AI answers"
+  },
+  "theme.SearchModal.askAiScreen.relatedSourcesText": {
+    "message": "Verwandte Quellen",
+    "description": "The text for related sources"
+  },
+  "theme.SearchModal.askAiScreen.thinkingText": {
+    "message": "Denkt nach...",
+    "description": "The text when AI is thinking"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonText": {
+    "message": "Kopieren",
+    "description": "The text for copy button"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonCopiedText": {
+    "message": "Kopiert!",
+    "description": "The text for copy button when copied"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonTitle": {
+    "message": "Kopieren",
+    "description": "The title for copy button"
+  },
+  "theme.SearchModal.askAiScreen.likeButtonTitle": {
+    "message": "Gefällt mir",
+    "description": "The title for like button"
+  },
+  "theme.SearchModal.askAiScreen.dislikeButtonTitle": {
+    "message": "Gefällt mir nicht",
+    "description": "The title for dislike button"
+  },
+  "theme.SearchModal.askAiScreen.thanksForFeedbackText": {
+    "message": "Danke für Ihr Feedback!",
+    "description": "The text for thanks for feedback"
+  },
+  "theme.SearchModal.askAiScreen.preToolCallText": {
+    "message": "Suche...",
+    "description": "The text before tool call"
+  },
+  "theme.SearchModal.askAiScreen.duringToolCallText": {
+    "message": "Suche nach ",
+    "description": "The text during tool call"
+  },
+  "theme.SearchModal.askAiScreen.afterToolCallText": {
+    "message": "Gesucht nach ",
+    "description": "The text after tool call"
+  },
+  "theme.SearchModal.footer.submitQuestionText": {
+    "message": "Frage absenden",
+    "description": "The submit question text for footer"
+  },
+  "theme.SearchModal.footer.backToSearchText": {
+    "message": "Zurück zur Suche",
+    "description": "The back to search text for footer"
   }
 }

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current.json
@@ -122,5 +122,29 @@
   "sidebar.documentationSidebar.category.Client Components": {
     "message": "Client-Komponenten",
     "description": "The label for category Client Components in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.AI Tooling": {
+    "message": "AI Tooling",
+    "description": "The label for category AI Tooling in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Kotlin DSL": {
+    "message": "Kotlin DSL",
+    "description": "The label for category Kotlin DSL in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Spring": {
+    "message": "Spring",
+    "description": "The label for category Spring in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Webswing": {
+    "message": "Webswing",
+    "description": "The label for category Webswing in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Security": {
+    "message": "Security",
+    "description": "The label for category Security in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.security-architecture": {
+    "message": "Architecture",
+    "description": "The label for category Architecture in sidebar documentationSidebar"
   }
 }

--- a/docs/i18n/de/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/de/docusaurus-theme-classic/navbar.json
@@ -62,5 +62,9 @@
   "item.label.Contact us": {
     "message": "Kontaktieren Sie uns",
     "description": "Navbar item with label Contact us"
+  },
+  "item.label.vlatest": {
+    "message": "vlatest",
+    "description": "Navbar item with label vlatest"
   }
 }

--- a/docs/i18n/en/code.json
+++ b/docs/i18n/en/code.json
@@ -836,5 +836,37 @@
   "theme.SearchModal.footer.backToSearchText": {
     "message": "Back to search",
     "description": "The back to search text for footer"
+  },
+  "chip.tooltipText.shadow": {
+    "message": "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.",
+    "description": "Hover text for components that render with a shadow DOM (document object model)"
+  },
+  "chip.label.shadow": {
+    "message": "Shadow",
+    "description": "Label to indicate a shadow DOM (document object model)"
+  },
+  "chip.tooltipText.name": {
+    "message": "The name of this web component as it appears in the DOM.",
+    "description": "Hover text to explain what version of webforJ you need to use the feature."
+  },
+  "chip.tooltipText.webforJ.version.snapshot": {
+    "message": "This feature will be available in a future release.",
+    "description": "Hover text to explain this feature is only available in a snapshot version of webforJ."
+  },
+  "chip.tooltipText.scoped": {
+    "message": "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.",
+    "description": "Hover text to explain this component is scoped, an alternative approach to the shadow DOM (document object model)."
+  },
+  "chip.label.scoped": {
+    "message": "Scoped",
+    "description": "Label to show this component uses scoped components."
+  },
+  "chip.tooltipText.experimental": {
+    "message": "This is an experimental feature and may change in future releases.",
+    "description": "Hover text to explain this feature is experimental and subject to change."
+  },
+  "chip.label.experimental": {
+    "message": "Experimental",
+    "description": "Label to show this component is experimental."
   }
 }

--- a/docs/i18n/es/code.json
+++ b/docs/i18n/es/code.json
@@ -395,7 +395,7 @@
   },
   "theme.SearchPage.algoliaLabel": {
     "message": "Buscar por Algolia",
-    "description": "The ARIA label for Algolia mention"
+    "description": "The description label for Algolia mention"
   },
   "theme.SearchPage.noResultsText": {
     "message": "No se encontraron resultados",
@@ -423,15 +423,15 @@
   },
   "theme.SearchModal.startScreen.noRecentSearchesText": {
     "message": "Sin búsquedas recientes",
-    "description": "The text when no recent searches"
+    "description": "The text when there are no recent searches"
   },
   "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
     "message": "Guardar esta búsqueda",
-    "description": "The label for save recent search button"
+    "description": "The title for save recent search button"
   },
   "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
     "message": "Eliminar esta búsqueda del historial",
-    "description": "The label for remove recent search button"
+    "description": "The title for remove recent search button"
   },
   "theme.SearchModal.startScreen.favoriteSearchesTitle": {
     "message": "Favorito",
@@ -439,63 +439,63 @@
   },
   "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
     "message": "Eliminar esta búsqueda de favoritos",
-    "description": "The label for remove favorite search button"
+    "description": "The title for remove favorite search button"
   },
   "theme.SearchModal.errorScreen.titleText": {
     "message": "No se pueden obtener resultados",
-    "description": "The title for error screen of search modal"
+    "description": "The title for error screen"
   },
   "theme.SearchModal.errorScreen.helpText": {
     "message": "Verifique su conexión a la red.",
-    "description": "The help text for error screen of search modal"
+    "description": "The help text for error screen"
   },
   "theme.SearchModal.footer.selectText": {
     "message": "para seleccionar",
-    "description": "The explanatory text of the action for the enter key"
+    "description": "The select text for footer"
   },
   "theme.SearchModal.footer.selectKeyAriaLabel": {
     "message": "Tecla Enter",
-    "description": "The ARIA label for the Enter key button that makes the selection"
+    "description": "The ARIA label for select key in footer"
   },
   "theme.SearchModal.footer.navigateText": {
     "message": "navegar",
-    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+    "description": "The navigate text for footer"
   },
   "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
     "message": "Flecha arriba",
-    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+    "description": "The ARIA label for navigate up key in footer"
   },
   "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
     "message": "Flecha abajo",
-    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+    "description": "The ARIA label for navigate down key in footer"
   },
   "theme.SearchModal.footer.closeText": {
     "message": "cerrar",
-    "description": "The explanatory text of the action for Escape key"
+    "description": "The close text for footer"
   },
   "theme.SearchModal.footer.closeKeyAriaLabel": {
     "message": "Tecla de escape",
-    "description": "The ARIA label for the Escape key button that close the modal"
+    "description": "The ARIA label for close key in footer"
   },
   "theme.SearchModal.footer.searchByText": {
     "message": "Buscar por",
-    "description": "The text explain that the search is making by Algolia"
+    "description": "The 'Powered by' text for footer"
   },
   "theme.SearchModal.noResultsScreen.noResultsText": {
     "message": "Sin resultados para",
-    "description": "The text explains that there are no results for the following search"
+    "description": "The text when there are no results"
   },
   "theme.SearchModal.noResultsScreen.suggestedQueryText": {
     "message": "Intenta buscar por",
-    "description": "The text for the suggested query when no results are found for the following search"
+    "description": "The text for suggested query"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
     "message": "¿Cree que esta consulta debería devolver resultados?",
-    "description": "The text for the question where the user thinks there are missing results"
+    "description": "The text for reporting missing results"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
     "message": "Háznoslo saber.",
-    "description": "The text for the link to report missing results"
+    "description": "The link text for reporting missing results"
   },
   "theme.SearchModal.placeholder": {
     "message": "Buscar docs",
@@ -712,5 +712,161 @@
   "componentArchetype.finalInstruction": {
     "message": "Después de ejecutar el comando, Maven generará los archivos del proyecto necesarios para ejecutar el proyecto.",
     "description": "Final instruction about Maven generating project files"
+  },
+  "running-the-app": {
+    "message": "Running the app",
+    "description": "Running the app title"
+  },
+  "component.archetype.running.app.desc": {
+    "message": "Before running your app, install the {prerequisites} if you haven't yet. Then, navigate to the project's root directory and run the following command:",
+    "description": "Running the app description"
+  },
+  "component.archetype.mvn.shorthand.title": {
+    "message": "Full maven command",
+    "description": "Full maven command note title"
+  },
+  "component.archetype.mvn.command.desc": {
+    "message": "The shorthand mvn command works because the archetype's POM file includes a {default} configuration that automatically runs the appropriate goal for your project type. If your project doesn't have {default}, run the following:",
+    "description": "Full maven command note description"
+  },
+  "component.archetype.browser.desc": {
+    "message": "Once the server is running, open your browser and go to {localhost} to view the app.",
+    "description": "running in the browser text"
+  },
+  "chip.tooltipText.shadow": {
+    "message": "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.",
+    "description": "Hover text for components that render with a shadow DOM (document object model)"
+  },
+  "chip.label.shadow": {
+    "message": "Shadow",
+    "description": "Label to indicate a shadow DOM (document object model)"
+  },
+  "chip.tooltipText.name": {
+    "message": "This feature is available for webforJ {version} and higher.",
+    "description": "Hover text to explain what version of webforJ you need to use the feature."
+  },
+  "chip.tooltipText.webforJ.version.snapshot": {
+    "message": "This feature will be available in a future release.",
+    "description": "Hover text to explain this feature is only available in a snapshot version of webforJ."
+  },
+  "chip.tooltipText.scoped": {
+    "message": "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.",
+    "description": "Hover text to explain this component is scoped, an alternative approach to the shadow DOM (document object model)."
+  },
+  "chip.label.scoped": {
+    "message": "Scoped",
+    "description": "Label to show this component uses scoped components."
+  },
+  "chip.tooltipText.experimental": {
+    "message": "This is an experimental feature and may change in future releases.",
+    "description": "Hover text to explain this feature is experimental and subject to change."
+  },
+  "chip.label.experimental": {
+    "message": "Experimental",
+    "description": "Label to show this component is experimental."
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.SearchModal.searchBox.placeholderText": {
+    "message": "Buscar documentos",
+    "description": "The placeholder text for the main search input field"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAi": {
+    "message": "Hacer otra pregunta...",
+    "description": "The placeholder text when in AI question mode"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAiStreaming": {
+    "message": "Respondiendo...",
+    "description": "The placeholder text for search box when AI is streaming an answer"
+  },
+  "theme.SearchModal.searchBox.enterKeyHint": {
+    "message": "buscar",
+    "description": "The hint for the search box enter key text"
+  },
+  "theme.SearchModal.searchBox.enterKeyHintAskAi": {
+    "message": "enviar",
+    "description": "The hint for the Ask AI search box enter key text"
+  },
+  "theme.SearchModal.searchBox.searchInputLabel": {
+    "message": "Buscar",
+    "description": "The ARIA label for search input"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
+    "message": "Volver a búsqueda por palabras clave",
+    "description": "The text for back to keyword search button"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonAriaLabel": {
+    "message": "Volver a búsqueda por palabras clave",
+    "description": "The ARIA label for back to keyword search button"
+  },
+  "theme.SearchModal.startScreen.recentConversationsTitle": {
+    "message": "Conversaciones recientes",
+    "description": "The title for recent conversations"
+  },
+  "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
+    "message": "Eliminar esta conversación del historial",
+    "description": "The title for remove recent conversation button"
+  },
+  "theme.SearchModal.resultsScreen.askAiPlaceholder": {
+    "message": "Preguntar a la IA: ",
+    "description": "The placeholder text for Ask AI input"
+  },
+  "theme.SearchModal.askAiScreen.disclaimerText": {
+    "message": "Las respuestas son generadas por IA y pueden contener errores. Verifique las respuestas.",
+    "description": "The disclaimer text for AI answers"
+  },
+  "theme.SearchModal.askAiScreen.relatedSourcesText": {
+    "message": "Fuentes relacionadas",
+    "description": "The text for related sources"
+  },
+  "theme.SearchModal.askAiScreen.thinkingText": {
+    "message": "Pensando...",
+    "description": "The text when AI is thinking"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonText": {
+    "message": "Copiar",
+    "description": "The text for copy button"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonCopiedText": {
+    "message": "¡Copiado!",
+    "description": "The text for copy button when copied"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonTitle": {
+    "message": "Copiar",
+    "description": "The title for copy button"
+  },
+  "theme.SearchModal.askAiScreen.likeButtonTitle": {
+    "message": "Me gusta",
+    "description": "The title for like button"
+  },
+  "theme.SearchModal.askAiScreen.dislikeButtonTitle": {
+    "message": "No me gusta",
+    "description": "The title for dislike button"
+  },
+  "theme.SearchModal.askAiScreen.thanksForFeedbackText": {
+    "message": "¡Gracias por tu opinión!",
+    "description": "The text for thanks for feedback"
+  },
+  "theme.SearchModal.askAiScreen.preToolCallText": {
+    "message": "Buscando...",
+    "description": "The text before tool call"
+  },
+  "theme.SearchModal.askAiScreen.duringToolCallText": {
+    "message": "Buscando ",
+    "description": "The text during tool call"
+  },
+  "theme.SearchModal.askAiScreen.afterToolCallText": {
+    "message": "Se buscó ",
+    "description": "The text after tool call"
+  },
+  "theme.SearchModal.footer.submitQuestionText": {
+    "message": "Enviar pregunta",
+    "description": "The submit question text for footer"
+  },
+  "theme.SearchModal.footer.backToSearchText": {
+    "message": "Volver a la búsqueda",
+    "description": "The back to search text for footer"
   }
 }

--- a/docs/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -122,5 +122,29 @@
   "sidebar.documentationSidebar.category.Client Components": {
     "message": "Componentes del Cliente",
     "description": "The label for category Client Components in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.AI Tooling": {
+    "message": "AI Tooling",
+    "description": "The label for category AI Tooling in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Kotlin DSL": {
+    "message": "Kotlin DSL",
+    "description": "The label for category Kotlin DSL in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Spring": {
+    "message": "Spring",
+    "description": "The label for category Spring in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Webswing": {
+    "message": "Webswing",
+    "description": "The label for category Webswing in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Security": {
+    "message": "Security",
+    "description": "The label for category Security in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.security-architecture": {
+    "message": "Architecture",
+    "description": "The label for category Architecture in sidebar documentationSidebar"
   }
 }

--- a/docs/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/es/docusaurus-theme-classic/navbar.json
@@ -62,5 +62,9 @@
   "item.label.Contact us": {
     "message": "Contáctanos",
     "description": "Navbar item with label Contact us"
+  },
+  "item.label.vlatest": {
+    "message": "vlatest",
+    "description": "Navbar item with label vlatest"
   }
 }

--- a/docs/i18n/fi/code.json
+++ b/docs/i18n/fi/code.json
@@ -392,7 +392,7 @@
   },
   "theme.SearchPage.algoliaLabel": {
     "message": "Haku Algolian avulla",
-    "description": "The ARIA label for Algolia mention"
+    "description": "The description label for Algolia mention"
   },
   "theme.SearchPage.noResultsText": {
     "message": "Ei tuloksia löytynyt",
@@ -423,15 +423,15 @@
   },
   "theme.SearchModal.startScreen.noRecentSearchesText": {
     "message": "Ei tuoreita hakuja",
-    "description": "The text when no recent searches"
+    "description": "The text when there are no recent searches"
   },
   "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
     "message": "Tallenna tämä haku",
-    "description": "The label for save recent search button"
+    "description": "The title for save recent search button"
   },
   "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
     "message": "Poista tämä haku historiasta",
-    "description": "The label for remove recent search button"
+    "description": "The title for remove recent search button"
   },
   "theme.SearchModal.startScreen.favoriteSearchesTitle": {
     "message": "Suosikki",
@@ -439,63 +439,63 @@
   },
   "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
     "message": "Poista tämä haku suosikeista",
-    "description": "The label for remove favorite search button"
+    "description": "The title for remove favorite search button"
   },
   "theme.SearchModal.errorScreen.titleText": {
     "message": "Tulosten hakeminen epäonnistui.",
-    "description": "The title for error screen of search modal"
+    "description": "The title for error screen"
   },
   "theme.SearchModal.errorScreen.helpText": {
     "message": "Tarkista mahdollisesti verkko- yhteytesi.",
-    "description": "The help text for error screen of search modal"
+    "description": "The help text for error screen"
   },
   "theme.SearchModal.footer.selectText": {
     "message": "valitse",
-    "description": "The explanatory text of the action for the enter key"
+    "description": "The select text for footer"
   },
   "theme.SearchModal.footer.selectKeyAriaLabel": {
     "message": "Syötä näppäin",
-    "description": "The ARIA label for the Enter key button that makes the selection"
+    "description": "The ARIA label for select key in footer"
   },
   "theme.SearchModal.footer.navigateText": {
     "message": "navigoida",
-    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+    "description": "The navigate text for footer"
   },
   "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
     "message": "Nuoli ylös",
-    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+    "description": "The ARIA label for navigate up key in footer"
   },
   "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
     "message": "Nuoli alas",
-    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+    "description": "The ARIA label for navigate down key in footer"
   },
   "theme.SearchModal.footer.closeText": {
     "message": "sulje",
-    "description": "The explanatory text of the action for Escape key"
+    "description": "The close text for footer"
   },
   "theme.SearchModal.footer.closeKeyAriaLabel": {
     "message": "Escape-näppäin",
-    "description": "The ARIA label for the Escape key button that close the modal"
+    "description": "The ARIA label for close key in footer"
   },
   "theme.SearchModal.footer.searchByText": {
     "message": "Hae perusteella",
-    "description": "The text explain that the search is making by Algolia"
+    "description": "The 'Powered by' text for footer"
   },
   "theme.SearchModal.noResultsScreen.noResultsText": {
     "message": "Ei tuloksia hakemallesi",
-    "description": "The text explains that there are no results for the following search"
+    "description": "The text when there are no results"
   },
   "theme.SearchModal.noResultsScreen.suggestedQueryText": {
     "message": "Kokeile hakua varten",
-    "description": "The text for the suggested query when no results are found for the following search"
+    "description": "The text for suggested query"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
     "message": "Uskotko, että tämä kysely palauttaa tuloksia?",
-    "description": "The text for the question where the user thinks there are missing results"
+    "description": "The text for reporting missing results"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
     "message": "Ilmoita meille.",
-    "description": "The text for the link to report missing results"
+    "description": "The link text for reporting missing results"
   },
   "theme.SearchModal.placeholder": {
     "message": "Etsi asiakirjoja",
@@ -712,5 +712,161 @@
   "componentArchetype.finalInstruction": {
     "message": "Maven luo tarvittavat projekti tiedostot projektin suorittamista varten komennon jälkeen.",
     "description": "Final instruction about Maven generating project files"
+  },
+  "running-the-app": {
+    "message": "Running the app",
+    "description": "Running the app title"
+  },
+  "component.archetype.running.app.desc": {
+    "message": "Before running your app, install the {prerequisites} if you haven't yet. Then, navigate to the project's root directory and run the following command:",
+    "description": "Running the app description"
+  },
+  "component.archetype.mvn.shorthand.title": {
+    "message": "Full maven command",
+    "description": "Full maven command note title"
+  },
+  "component.archetype.mvn.command.desc": {
+    "message": "The shorthand mvn command works because the archetype's POM file includes a {default} configuration that automatically runs the appropriate goal for your project type. If your project doesn't have {default}, run the following:",
+    "description": "Full maven command note description"
+  },
+  "component.archetype.browser.desc": {
+    "message": "Once the server is running, open your browser and go to {localhost} to view the app.",
+    "description": "running in the browser text"
+  },
+  "chip.tooltipText.shadow": {
+    "message": "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.",
+    "description": "Hover text for components that render with a shadow DOM (document object model)"
+  },
+  "chip.label.shadow": {
+    "message": "Shadow",
+    "description": "Label to indicate a shadow DOM (document object model)"
+  },
+  "chip.tooltipText.name": {
+    "message": "This feature is available for webforJ {version} and higher.",
+    "description": "Hover text to explain what version of webforJ you need to use the feature."
+  },
+  "chip.tooltipText.webforJ.version.snapshot": {
+    "message": "This feature will be available in a future release.",
+    "description": "Hover text to explain this feature is only available in a snapshot version of webforJ."
+  },
+  "chip.tooltipText.scoped": {
+    "message": "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.",
+    "description": "Hover text to explain this component is scoped, an alternative approach to the shadow DOM (document object model)."
+  },
+  "chip.label.scoped": {
+    "message": "Scoped",
+    "description": "Label to show this component uses scoped components."
+  },
+  "chip.tooltipText.experimental": {
+    "message": "This is an experimental feature and may change in future releases.",
+    "description": "Hover text to explain this feature is experimental and subject to change."
+  },
+  "chip.label.experimental": {
+    "message": "Experimental",
+    "description": "Label to show this component is experimental."
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.SearchModal.searchBox.placeholderText": {
+    "message": "Search docs",
+    "description": "The placeholder text for the main search input field"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAi": {
+    "message": "Ask another question...",
+    "description": "The placeholder text when in AI question mode"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAiStreaming": {
+    "message": "Answering...",
+    "description": "The placeholder text for search box when AI is streaming an answer"
+  },
+  "theme.SearchModal.searchBox.enterKeyHint": {
+    "message": "search",
+    "description": "The hint for the search box enter key text"
+  },
+  "theme.SearchModal.searchBox.enterKeyHintAskAi": {
+    "message": "enter",
+    "description": "The hint for the Ask AI search box enter key text"
+  },
+  "theme.SearchModal.searchBox.searchInputLabel": {
+    "message": "Search",
+    "description": "The ARIA label for search input"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
+    "message": "Back to keyword search",
+    "description": "The text for back to keyword search button"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonAriaLabel": {
+    "message": "Back to keyword search",
+    "description": "The ARIA label for back to keyword search button"
+  },
+  "theme.SearchModal.startScreen.recentConversationsTitle": {
+    "message": "Recent conversations",
+    "description": "The title for recent conversations"
+  },
+  "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
+    "message": "Remove this conversation from history",
+    "description": "The title for remove recent conversation button"
+  },
+  "theme.SearchModal.resultsScreen.askAiPlaceholder": {
+    "message": "Ask AI: ",
+    "description": "The placeholder text for Ask AI input"
+  },
+  "theme.SearchModal.askAiScreen.disclaimerText": {
+    "message": "Answers are generated with AI which can make mistakes. Verify responses.",
+    "description": "The disclaimer text for AI answers"
+  },
+  "theme.SearchModal.askAiScreen.relatedSourcesText": {
+    "message": "Related sources",
+    "description": "The text for related sources"
+  },
+  "theme.SearchModal.askAiScreen.thinkingText": {
+    "message": "Thinking...",
+    "description": "The text when AI is thinking"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonText": {
+    "message": "Copy",
+    "description": "The text for copy button"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonCopiedText": {
+    "message": "Copied!",
+    "description": "The text for copy button when copied"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonTitle": {
+    "message": "Copy",
+    "description": "The title for copy button"
+  },
+  "theme.SearchModal.askAiScreen.likeButtonTitle": {
+    "message": "Like",
+    "description": "The title for like button"
+  },
+  "theme.SearchModal.askAiScreen.dislikeButtonTitle": {
+    "message": "Dislike",
+    "description": "The title for dislike button"
+  },
+  "theme.SearchModal.askAiScreen.thanksForFeedbackText": {
+    "message": "Thanks for your feedback!",
+    "description": "The text for thanks for feedback"
+  },
+  "theme.SearchModal.askAiScreen.preToolCallText": {
+    "message": "Searching...",
+    "description": "The text before tool call"
+  },
+  "theme.SearchModal.askAiScreen.duringToolCallText": {
+    "message": "Searching for ",
+    "description": "The text during tool call"
+  },
+  "theme.SearchModal.askAiScreen.afterToolCallText": {
+    "message": "Searched for",
+    "description": "The text after tool call"
+  },
+  "theme.SearchModal.footer.submitQuestionText": {
+    "message": "Submit question",
+    "description": "The submit question text for footer"
+  },
+  "theme.SearchModal.footer.backToSearchText": {
+    "message": "Back to search",
+    "description": "The back to search text for footer"
   }
 }

--- a/docs/i18n/fi/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/fi/docusaurus-plugin-content-docs/current.json
@@ -122,5 +122,29 @@
   "sidebar.documentationSidebar.category.Client Components": {
     "message": "Asiakaskomponentit",
     "description": "The label for category Client Components in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.AI Tooling": {
+    "message": "AI Tooling",
+    "description": "The label for category AI Tooling in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Kotlin DSL": {
+    "message": "Kotlin DSL",
+    "description": "The label for category Kotlin DSL in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Spring": {
+    "message": "Spring",
+    "description": "The label for category Spring in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Webswing": {
+    "message": "Webswing",
+    "description": "The label for category Webswing in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Security": {
+    "message": "Security",
+    "description": "The label for category Security in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.security-architecture": {
+    "message": "Architecture",
+    "description": "The label for category Architecture in sidebar documentationSidebar"
   }
 }

--- a/docs/i18n/fi/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/fi/docusaurus-theme-classic/navbar.json
@@ -62,5 +62,9 @@
   "item.label.Contact us": {
     "message": "Ota meihin yhteyttä",
     "description": "Navbar item with label Contact us"
+  },
+  "item.label.vlatest": {
+    "message": "vlatest",
+    "description": "Navbar item with label vlatest"
   }
 }

--- a/docs/i18n/fr/code.json
+++ b/docs/i18n/fr/code.json
@@ -395,7 +395,7 @@
   },
   "theme.SearchPage.algoliaLabel": {
     "message": "Recherche par Algolia",
-    "description": "The ARIA label for Algolia mention"
+    "description": "The description label for Algolia mention"
   },
   "theme.SearchPage.noResultsText": {
     "message": "Aucun résultat trouvé",
@@ -423,15 +423,15 @@
   },
   "theme.SearchModal.startScreen.noRecentSearchesText": {
     "message": "Aucune recherche récente",
-    "description": "The text when no recent searches"
+    "description": "The text when there are no recent searches"
   },
   "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
     "message": "Enregistrer cette recherche",
-    "description": "The label for save recent search button"
+    "description": "The title for save recent search button"
   },
   "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
     "message": "Supprimer cette recherche de l'historique",
-    "description": "The label for remove recent search button"
+    "description": "The title for remove recent search button"
   },
   "theme.SearchModal.startScreen.favoriteSearchesTitle": {
     "message": "Favori",
@@ -439,63 +439,63 @@
   },
   "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
     "message": "Retirer cette recherche des favoris",
-    "description": "The label for remove favorite search button"
+    "description": "The title for remove favorite search button"
   },
   "theme.SearchModal.errorScreen.titleText": {
     "message": "Impossible de récupérer les résultats",
-    "description": "The title for error screen of search modal"
+    "description": "The title for error screen"
   },
   "theme.SearchModal.errorScreen.helpText": {
     "message": "Vérifiez votre connexion réseau.",
-    "description": "The help text for error screen of search modal"
+    "description": "The help text for error screen"
   },
   "theme.SearchModal.footer.selectText": {
     "message": "sélectionner",
-    "description": "The explanatory text of the action for the enter key"
+    "description": "The select text for footer"
   },
   "theme.SearchModal.footer.selectKeyAriaLabel": {
     "message": "Touche Entrée",
-    "description": "The ARIA label for the Enter key button that makes the selection"
+    "description": "The ARIA label for select key in footer"
   },
   "theme.SearchModal.footer.navigateText": {
     "message": "naviguer",
-    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+    "description": "The navigate text for footer"
   },
   "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
     "message": "Flèche vers le haut",
-    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+    "description": "The ARIA label for navigate up key in footer"
   },
   "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
     "message": "Flèche bas",
-    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+    "description": "The ARIA label for navigate down key in footer"
   },
   "theme.SearchModal.footer.closeText": {
     "message": "fermer",
-    "description": "The explanatory text of the action for Escape key"
+    "description": "The close text for footer"
   },
   "theme.SearchModal.footer.closeKeyAriaLabel": {
     "message": "Touche Échap",
-    "description": "The ARIA label for the Escape key button that close the modal"
+    "description": "The ARIA label for close key in footer"
   },
   "theme.SearchModal.footer.searchByText": {
     "message": "Rechercher par",
-    "description": "The text explain that the search is making by Algolia"
+    "description": "The 'Powered by' text for footer"
   },
   "theme.SearchModal.noResultsScreen.noResultsText": {
     "message": "Aucun résultat pour",
-    "description": "The text explains that there are no results for the following search"
+    "description": "The text when there are no results"
   },
   "theme.SearchModal.noResultsScreen.suggestedQueryText": {
     "message": "Essayez de rechercher",
-    "description": "The text for the suggested query when no results are found for the following search"
+    "description": "The text for suggested query"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
     "message": "Croyez-vous que cette requête devrait renvoyer des résultats ?",
-    "description": "The text for the question where the user thinks there are missing results"
+    "description": "The text for reporting missing results"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
     "message": "Faites-le nous savoir.",
-    "description": "The text for the link to report missing results"
+    "description": "The link text for reporting missing results"
   },
   "theme.SearchModal.placeholder": {
     "message": "Rechercher des docs",
@@ -712,5 +712,161 @@
   "componentArchetype.finalInstruction": {
     "message": "Après l'exécution de la commande, Maven générera les fichiers nécessaires pour exécuter le projet.",
     "description": "Final instruction about Maven generating project files"
+  },
+  "running-the-app": {
+    "message": "Running the app",
+    "description": "Running the app title"
+  },
+  "component.archetype.running.app.desc": {
+    "message": "Before running your app, install the {prerequisites} if you haven't yet. Then, navigate to the project's root directory and run the following command:",
+    "description": "Running the app description"
+  },
+  "component.archetype.mvn.shorthand.title": {
+    "message": "Full maven command",
+    "description": "Full maven command note title"
+  },
+  "component.archetype.mvn.command.desc": {
+    "message": "The shorthand mvn command works because the archetype's POM file includes a {default} configuration that automatically runs the appropriate goal for your project type. If your project doesn't have {default}, run the following:",
+    "description": "Full maven command note description"
+  },
+  "component.archetype.browser.desc": {
+    "message": "Once the server is running, open your browser and go to {localhost} to view the app.",
+    "description": "running in the browser text"
+  },
+  "chip.tooltipText.shadow": {
+    "message": "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.",
+    "description": "Hover text for components that render with a shadow DOM (document object model)"
+  },
+  "chip.label.shadow": {
+    "message": "Shadow",
+    "description": "Label to indicate a shadow DOM (document object model)"
+  },
+  "chip.tooltipText.name": {
+    "message": "This feature is available for webforJ {version} and higher.",
+    "description": "Hover text to explain what version of webforJ you need to use the feature."
+  },
+  "chip.tooltipText.webforJ.version.snapshot": {
+    "message": "This feature will be available in a future release.",
+    "description": "Hover text to explain this feature is only available in a snapshot version of webforJ."
+  },
+  "chip.tooltipText.scoped": {
+    "message": "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.",
+    "description": "Hover text to explain this component is scoped, an alternative approach to the shadow DOM (document object model)."
+  },
+  "chip.label.scoped": {
+    "message": "Scoped",
+    "description": "Label to show this component uses scoped components."
+  },
+  "chip.tooltipText.experimental": {
+    "message": "This is an experimental feature and may change in future releases.",
+    "description": "Hover text to explain this feature is experimental and subject to change."
+  },
+  "chip.label.experimental": {
+    "message": "Experimental",
+    "description": "Label to show this component is experimental."
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.SearchModal.searchBox.placeholderText": {
+    "message": "Rechercher des docs",
+    "description": "The placeholder text for the main search input field"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAi": {
+    "message": "Poser une autre question...",
+    "description": "The placeholder text when in AI question mode"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAiStreaming": {
+    "message": "En train de répondre...",
+    "description": "The placeholder text for search box when AI is streaming an answer"
+  },
+  "theme.SearchModal.searchBox.enterKeyHint": {
+    "message": "rechercher",
+    "description": "The hint for the search box enter key text"
+  },
+  "theme.SearchModal.searchBox.enterKeyHintAskAi": {
+    "message": "entrée",
+    "description": "The hint for the Ask AI search box enter key text"
+  },
+  "theme.SearchModal.searchBox.searchInputLabel": {
+    "message": "Rechercher",
+    "description": "The ARIA label for search input"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
+    "message": "Retour à la recherche par mots-clés",
+    "description": "The text for back to keyword search button"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonAriaLabel": {
+    "message": "Retour à la recherche par mots-clés",
+    "description": "The ARIA label for back to keyword search button"
+  },
+  "theme.SearchModal.startScreen.recentConversationsTitle": {
+    "message": "Conversations récentes",
+    "description": "The title for recent conversations"
+  },
+  "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
+    "message": "Supprimer cette conversation de l'historique",
+    "description": "The title for remove recent conversation button"
+  },
+  "theme.SearchModal.resultsScreen.askAiPlaceholder": {
+    "message": "Demander à l'IA : ",
+    "description": "The placeholder text for Ask AI input"
+  },
+  "theme.SearchModal.askAiScreen.disclaimerText": {
+    "message": "Les réponses sont générées par l'IA et peuvent contenir des erreurs. Veuillez vérifier les réponses.",
+    "description": "The disclaimer text for AI answers"
+  },
+  "theme.SearchModal.askAiScreen.relatedSourcesText": {
+    "message": "Sources connexes",
+    "description": "The text for related sources"
+  },
+  "theme.SearchModal.askAiScreen.thinkingText": {
+    "message": "Réflexion en cours...",
+    "description": "The text when AI is thinking"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonText": {
+    "message": "Copier",
+    "description": "The text for copy button"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonCopiedText": {
+    "message": "Copié !",
+    "description": "The text for copy button when copied"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonTitle": {
+    "message": "Copier",
+    "description": "The title for copy button"
+  },
+  "theme.SearchModal.askAiScreen.likeButtonTitle": {
+    "message": "J'aime",
+    "description": "The title for like button"
+  },
+  "theme.SearchModal.askAiScreen.dislikeButtonTitle": {
+    "message": "Je n'aime pas",
+    "description": "The title for dislike button"
+  },
+  "theme.SearchModal.askAiScreen.thanksForFeedbackText": {
+    "message": "Merci pour votre retour !",
+    "description": "The text for thanks for feedback"
+  },
+  "theme.SearchModal.askAiScreen.preToolCallText": {
+    "message": "Recherche en cours...",
+    "description": "The text before tool call"
+  },
+  "theme.SearchModal.askAiScreen.duringToolCallText": {
+    "message": "Recherche de ",
+    "description": "The text during tool call"
+  },
+  "theme.SearchModal.askAiScreen.afterToolCallText": {
+    "message": "Recherche effectuée pour ",
+    "description": "The text after tool call"
+  },
+  "theme.SearchModal.footer.submitQuestionText": {
+    "message": "Soumettre la question",
+    "description": "The submit question text for footer"
+  },
+  "theme.SearchModal.footer.backToSearchText": {
+    "message": "Retour à la recherche",
+    "description": "The back to search text for footer"
   }
 }

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current.json
@@ -122,5 +122,29 @@
   "sidebar.documentationSidebar.category.Client Components": {
     "message": "Composants Client",
     "description": "The label for category Client Components in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.AI Tooling": {
+    "message": "AI Tooling",
+    "description": "The label for category AI Tooling in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Kotlin DSL": {
+    "message": "Kotlin DSL",
+    "description": "The label for category Kotlin DSL in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Spring": {
+    "message": "Spring",
+    "description": "The label for category Spring in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Webswing": {
+    "message": "Webswing",
+    "description": "The label for category Webswing in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Security": {
+    "message": "Security",
+    "description": "The label for category Security in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.security-architecture": {
+    "message": "Architecture",
+    "description": "The label for category Architecture in sidebar documentationSidebar"
   }
 }

--- a/docs/i18n/fr/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/fr/docusaurus-theme-classic/navbar.json
@@ -62,5 +62,9 @@
   "item.label.Contact us": {
     "message": "Contactez-nous",
     "description": "Navbar item with label Contact us"
+  },
+  "item.label.vlatest": {
+    "message": "vlatest",
+    "description": "Navbar item with label vlatest"
   }
 }

--- a/docs/i18n/nl/code.json
+++ b/docs/i18n/nl/code.json
@@ -395,7 +395,7 @@
   },
   "theme.SearchPage.algoliaLabel": {
     "message": "Zoeken via Algolia",
-    "description": "The ARIA label for Algolia mention"
+    "description": "The description label for Algolia mention"
   },
   "theme.SearchPage.noResultsText": {
     "message": "Geen resultaten gevonden",
@@ -423,15 +423,15 @@
   },
   "theme.SearchModal.startScreen.noRecentSearchesText": {
     "message": "Geen recente zoekopdrachten",
-    "description": "The text when no recent searches"
+    "description": "The text when there are no recent searches"
   },
   "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
     "message": "Bewaar deze zoekopdracht",
-    "description": "The label for save recent search button"
+    "description": "The title for save recent search button"
   },
   "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
     "message": "Verwijder deze zoekopdracht uit de geschiedenis",
-    "description": "The label for remove recent search button"
+    "description": "The title for remove recent search button"
   },
   "theme.SearchModal.startScreen.favoriteSearchesTitle": {
     "message": "Favoriet",
@@ -439,63 +439,63 @@
   },
   "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
     "message": "Verwijder deze zoekopdracht uit favorieten",
-    "description": "The label for remove favorite search button"
+    "description": "The title for remove favorite search button"
   },
   "theme.SearchModal.errorScreen.titleText": {
     "message": "Resultaten kunnen niet opgehaald worden",
-    "description": "The title for error screen of search modal"
+    "description": "The title for error screen"
   },
   "theme.SearchModal.errorScreen.helpText": {
     "message": "Controleer uw netwerkverbinding.",
-    "description": "The help text for error screen of search modal"
+    "description": "The help text for error screen"
   },
   "theme.SearchModal.footer.selectText": {
     "message": "selecteren",
-    "description": "The explanatory text of the action for the enter key"
+    "description": "The select text for footer"
   },
   "theme.SearchModal.footer.selectKeyAriaLabel": {
     "message": "Voer toets in",
-    "description": "The ARIA label for the Enter key button that makes the selection"
+    "description": "The ARIA label for select key in footer"
   },
   "theme.SearchModal.footer.navigateText": {
     "message": "navigeren",
-    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+    "description": "The navigate text for footer"
   },
   "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
     "message": "Pijl omhoog",
-    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+    "description": "The ARIA label for navigate up key in footer"
   },
   "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
     "message": "Pijl omlaag",
-    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+    "description": "The ARIA label for navigate down key in footer"
   },
   "theme.SearchModal.footer.closeText": {
     "message": "sluiten",
-    "description": "The explanatory text of the action for Escape key"
+    "description": "The close text for footer"
   },
   "theme.SearchModal.footer.closeKeyAriaLabel": {
     "message": "Esc-toets",
-    "description": "The ARIA label for the Escape key button that close the modal"
+    "description": "The ARIA label for close key in footer"
   },
   "theme.SearchModal.footer.searchByText": {
     "message": "Zoeken op",
-    "description": "The text explain that the search is making by Algolia"
+    "description": "The 'Powered by' text for footer"
   },
   "theme.SearchModal.noResultsScreen.noResultsText": {
     "message": "Geen resultaten voor",
-    "description": "The text explains that there are no results for the following search"
+    "description": "The text when there are no results"
   },
   "theme.SearchModal.noResultsScreen.suggestedQueryText": {
     "message": "Probeer te zoeken naar",
-    "description": "The text for the suggested query when no results are found for the following search"
+    "description": "The text for suggested query"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
     "message": "Gelooft u dat deze query resultaten zou moeten retourneren?",
-    "description": "The text for the question where the user thinks there are missing results"
+    "description": "The text for reporting missing results"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
     "message": "Laat het ons weten.",
-    "description": "The text for the link to report missing results"
+    "description": "The link text for reporting missing results"
   },
   "theme.SearchModal.placeholder": {
     "message": "Zoek documentatie",
@@ -712,5 +712,161 @@
   "componentArchetype.finalInstruction": {
     "message": "Na het uitvoeren van de opdracht genereert Maven de projectbestanden die nodig zijn om het project uit te voeren.",
     "description": "Final instruction about Maven generating project files"
+  },
+  "running-the-app": {
+    "message": "Running the app",
+    "description": "Running the app title"
+  },
+  "component.archetype.running.app.desc": {
+    "message": "Before running your app, install the {prerequisites} if you haven't yet. Then, navigate to the project's root directory and run the following command:",
+    "description": "Running the app description"
+  },
+  "component.archetype.mvn.shorthand.title": {
+    "message": "Full maven command",
+    "description": "Full maven command note title"
+  },
+  "component.archetype.mvn.command.desc": {
+    "message": "The shorthand mvn command works because the archetype's POM file includes a {default} configuration that automatically runs the appropriate goal for your project type. If your project doesn't have {default}, run the following:",
+    "description": "Full maven command note description"
+  },
+  "component.archetype.browser.desc": {
+    "message": "Once the server is running, open your browser and go to {localhost} to view the app.",
+    "description": "running in the browser text"
+  },
+  "chip.tooltipText.shadow": {
+    "message": "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.",
+    "description": "Hover text for components that render with a shadow DOM (document object model)"
+  },
+  "chip.label.shadow": {
+    "message": "Shadow",
+    "description": "Label to indicate a shadow DOM (document object model)"
+  },
+  "chip.tooltipText.name": {
+    "message": "This feature is available for webforJ {version} and higher.",
+    "description": "Hover text to explain what version of webforJ you need to use the feature."
+  },
+  "chip.tooltipText.webforJ.version.snapshot": {
+    "message": "This feature will be available in a future release.",
+    "description": "Hover text to explain this feature is only available in a snapshot version of webforJ."
+  },
+  "chip.tooltipText.scoped": {
+    "message": "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.",
+    "description": "Hover text to explain this component is scoped, an alternative approach to the shadow DOM (document object model)."
+  },
+  "chip.label.scoped": {
+    "message": "Scoped",
+    "description": "Label to show this component uses scoped components."
+  },
+  "chip.tooltipText.experimental": {
+    "message": "This is an experimental feature and may change in future releases.",
+    "description": "Hover text to explain this feature is experimental and subject to change."
+  },
+  "chip.label.experimental": {
+    "message": "Experimental",
+    "description": "Label to show this component is experimental."
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.SearchModal.searchBox.placeholderText": {
+    "message": "Search docs",
+    "description": "The placeholder text for the main search input field"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAi": {
+    "message": "Ask another question...",
+    "description": "The placeholder text when in AI question mode"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAiStreaming": {
+    "message": "Answering...",
+    "description": "The placeholder text for search box when AI is streaming an answer"
+  },
+  "theme.SearchModal.searchBox.enterKeyHint": {
+    "message": "search",
+    "description": "The hint for the search box enter key text"
+  },
+  "theme.SearchModal.searchBox.enterKeyHintAskAi": {
+    "message": "enter",
+    "description": "The hint for the Ask AI search box enter key text"
+  },
+  "theme.SearchModal.searchBox.searchInputLabel": {
+    "message": "Search",
+    "description": "The ARIA label for search input"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
+    "message": "Back to keyword search",
+    "description": "The text for back to keyword search button"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonAriaLabel": {
+    "message": "Back to keyword search",
+    "description": "The ARIA label for back to keyword search button"
+  },
+  "theme.SearchModal.startScreen.recentConversationsTitle": {
+    "message": "Recent conversations",
+    "description": "The title for recent conversations"
+  },
+  "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
+    "message": "Remove this conversation from history",
+    "description": "The title for remove recent conversation button"
+  },
+  "theme.SearchModal.resultsScreen.askAiPlaceholder": {
+    "message": "Ask AI: ",
+    "description": "The placeholder text for Ask AI input"
+  },
+  "theme.SearchModal.askAiScreen.disclaimerText": {
+    "message": "Answers are generated with AI which can make mistakes. Verify responses.",
+    "description": "The disclaimer text for AI answers"
+  },
+  "theme.SearchModal.askAiScreen.relatedSourcesText": {
+    "message": "Related sources",
+    "description": "The text for related sources"
+  },
+  "theme.SearchModal.askAiScreen.thinkingText": {
+    "message": "Thinking...",
+    "description": "The text when AI is thinking"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonText": {
+    "message": "Copy",
+    "description": "The text for copy button"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonCopiedText": {
+    "message": "Copied!",
+    "description": "The text for copy button when copied"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonTitle": {
+    "message": "Copy",
+    "description": "The title for copy button"
+  },
+  "theme.SearchModal.askAiScreen.likeButtonTitle": {
+    "message": "Like",
+    "description": "The title for like button"
+  },
+  "theme.SearchModal.askAiScreen.dislikeButtonTitle": {
+    "message": "Dislike",
+    "description": "The title for dislike button"
+  },
+  "theme.SearchModal.askAiScreen.thanksForFeedbackText": {
+    "message": "Thanks for your feedback!",
+    "description": "The text for thanks for feedback"
+  },
+  "theme.SearchModal.askAiScreen.preToolCallText": {
+    "message": "Searching...",
+    "description": "The text before tool call"
+  },
+  "theme.SearchModal.askAiScreen.duringToolCallText": {
+    "message": "Searching for ",
+    "description": "The text during tool call"
+  },
+  "theme.SearchModal.askAiScreen.afterToolCallText": {
+    "message": "Searched for",
+    "description": "The text after tool call"
+  },
+  "theme.SearchModal.footer.submitQuestionText": {
+    "message": "Submit question",
+    "description": "The submit question text for footer"
+  },
+  "theme.SearchModal.footer.backToSearchText": {
+    "message": "Back to search",
+    "description": "The back to search text for footer"
   }
 }

--- a/docs/i18n/nl/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/nl/docusaurus-plugin-content-docs/current.json
@@ -122,5 +122,29 @@
   "sidebar.documentationSidebar.category.Client Components": {
     "message": "Klantcomponenten",
     "description": "The label for category Client Components in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.AI Tooling": {
+    "message": "AI Tooling",
+    "description": "The label for category AI Tooling in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Kotlin DSL": {
+    "message": "Kotlin DSL",
+    "description": "The label for category Kotlin DSL in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Spring": {
+    "message": "Spring",
+    "description": "The label for category Spring in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Webswing": {
+    "message": "Webswing",
+    "description": "The label for category Webswing in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Security": {
+    "message": "Security",
+    "description": "The label for category Security in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.security-architecture": {
+    "message": "Architecture",
+    "description": "The label for category Architecture in sidebar documentationSidebar"
   }
 }

--- a/docs/i18n/nl/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/nl/docusaurus-theme-classic/navbar.json
@@ -62,5 +62,9 @@
   "item.label.Contact us": {
     "message": "Neem contact met ons op",
     "description": "Navbar item with label Contact us"
+  },
+  "item.label.vlatest": {
+    "message": "vlatest",
+    "description": "Navbar item with label vlatest"
   }
 }

--- a/docs/i18n/zh/code.json
+++ b/docs/i18n/zh/code.json
@@ -395,7 +395,7 @@
   },
   "theme.SearchPage.algoliaLabel": {
     "message": "通过Algolia搜索",
-    "description": "The ARIA label for Algolia mention"
+    "description": "The description label for Algolia mention"
   },
   "theme.SearchPage.noResultsText": {
     "message": "未找到结果",
@@ -423,15 +423,15 @@
   },
   "theme.SearchModal.startScreen.noRecentSearchesText": {
     "message": "没有最近的搜索",
-    "description": "The text when no recent searches"
+    "description": "The text when there are no recent searches"
   },
   "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
     "message": "保存此搜索",
-    "description": "The label for save recent search button"
+    "description": "The title for save recent search button"
   },
   "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
     "message": "从历史中移除此搜索",
-    "description": "The label for remove recent search button"
+    "description": "The title for remove recent search button"
   },
   "theme.SearchModal.startScreen.favoriteSearchesTitle": {
     "message": "收藏",
@@ -439,63 +439,63 @@
   },
   "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
     "message": "从收藏夹中移除此搜索",
-    "description": "The label for remove favorite search button"
+    "description": "The title for remove favorite search button"
   },
   "theme.SearchModal.errorScreen.titleText": {
     "message": "无法获取结果",
-    "description": "The title for error screen of search modal"
+    "description": "The title for error screen"
   },
   "theme.SearchModal.errorScreen.helpText": {
     "message": "请检查您的网络连接。",
-    "description": "The help text for error screen of search modal"
+    "description": "The help text for error screen"
   },
   "theme.SearchModal.footer.selectText": {
     "message": "选择",
-    "description": "The explanatory text of the action for the enter key"
+    "description": "The select text for footer"
   },
   "theme.SearchModal.footer.selectKeyAriaLabel": {
     "message": "确认键",
-    "description": "The ARIA label for the Enter key button that makes the selection"
+    "description": "The ARIA label for select key in footer"
   },
   "theme.SearchModal.footer.navigateText": {
     "message": "导航",
-    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+    "description": "The navigate text for footer"
   },
   "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
     "message": "向上箭头",
-    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+    "description": "The ARIA label for navigate up key in footer"
   },
   "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
     "message": "向下箭头",
-    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+    "description": "The ARIA label for navigate down key in footer"
   },
   "theme.SearchModal.footer.closeText": {
     "message": "关闭",
-    "description": "The explanatory text of the action for Escape key"
+    "description": "The close text for footer"
   },
   "theme.SearchModal.footer.closeKeyAriaLabel": {
     "message": "退出键",
-    "description": "The ARIA label for the Escape key button that close the modal"
+    "description": "The ARIA label for close key in footer"
   },
   "theme.SearchModal.footer.searchByText": {
     "message": "按…搜索",
-    "description": "The text explain that the search is making by Algolia"
+    "description": "The 'Powered by' text for footer"
   },
   "theme.SearchModal.noResultsScreen.noResultsText": {
     "message": "没有结果 для",
-    "description": "The text explains that there are no results for the following search"
+    "description": "The text when there are no results"
   },
   "theme.SearchModal.noResultsScreen.suggestedQueryText": {
     "message": "尝试搜索",
-    "description": "The text for the suggested query when no results are found for the following search"
+    "description": "The text for suggested query"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
     "message": "相信此查询应该返回结果？",
-    "description": "The text for the question where the user thinks there are missing results"
+    "description": "The text for reporting missing results"
   },
   "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
     "message": "告诉我们。",
-    "description": "The text for the link to report missing results"
+    "description": "The link text for reporting missing results"
   },
   "theme.SearchModal.placeholder": {
     "message": "搜索文档",
@@ -712,5 +712,161 @@
   "componentArchetype.finalInstruction": {
     "message": "运行该命令后，Maven 将生成运行项目所需的项目文件。",
     "description": "Final instruction about Maven generating project files"
+  },
+  "running-the-app": {
+    "message": "Running the app",
+    "description": "Running the app title"
+  },
+  "component.archetype.running.app.desc": {
+    "message": "Before running your app, install the {prerequisites} if you haven't yet. Then, navigate to the project's root directory and run the following command:",
+    "description": "Running the app description"
+  },
+  "component.archetype.mvn.shorthand.title": {
+    "message": "Full maven command",
+    "description": "Full maven command note title"
+  },
+  "component.archetype.mvn.command.desc": {
+    "message": "The shorthand mvn command works because the archetype's POM file includes a {default} configuration that automatically runs the appropriate goal for your project type. If your project doesn't have {default}, run the following:",
+    "description": "Full maven command note description"
+  },
+  "component.archetype.browser.desc": {
+    "message": "Once the server is running, open your browser and go to {localhost} to view the app.",
+    "description": "running in the browser text"
+  },
+  "chip.tooltipText.shadow": {
+    "message": "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.",
+    "description": "Hover text for components that render with a shadow DOM (document object model)"
+  },
+  "chip.label.shadow": {
+    "message": "Shadow",
+    "description": "Label to indicate a shadow DOM (document object model)"
+  },
+  "chip.tooltipText.name": {
+    "message": "This feature is available for webforJ {version} and higher.",
+    "description": "Hover text to explain what version of webforJ you need to use the feature."
+  },
+  "chip.tooltipText.webforJ.version.snapshot": {
+    "message": "This feature will be available in a future release.",
+    "description": "Hover text to explain this feature is only available in a snapshot version of webforJ."
+  },
+  "chip.tooltipText.scoped": {
+    "message": "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.",
+    "description": "Hover text to explain this component is scoped, an alternative approach to the shadow DOM (document object model)."
+  },
+  "chip.label.scoped": {
+    "message": "Scoped",
+    "description": "Label to show this component uses scoped components."
+  },
+  "chip.tooltipText.experimental": {
+    "message": "This is an experimental feature and may change in future releases.",
+    "description": "Hover text to explain this feature is experimental and subject to change."
+  },
+  "chip.label.experimental": {
+    "message": "Experimental",
+    "description": "Label to show this component is experimental."
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(opens in new tab)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.SearchModal.searchBox.placeholderText": {
+    "message": "Search docs",
+    "description": "The placeholder text for the main search input field"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAi": {
+    "message": "Ask another question...",
+    "description": "The placeholder text when in AI question mode"
+  },
+  "theme.SearchModal.searchBox.placeholderTextAskAiStreaming": {
+    "message": "Answering...",
+    "description": "The placeholder text for search box when AI is streaming an answer"
+  },
+  "theme.SearchModal.searchBox.enterKeyHint": {
+    "message": "search",
+    "description": "The hint for the search box enter key text"
+  },
+  "theme.SearchModal.searchBox.enterKeyHintAskAi": {
+    "message": "enter",
+    "description": "The hint for the Ask AI search box enter key text"
+  },
+  "theme.SearchModal.searchBox.searchInputLabel": {
+    "message": "Search",
+    "description": "The ARIA label for search input"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonText": {
+    "message": "Back to keyword search",
+    "description": "The text for back to keyword search button"
+  },
+  "theme.SearchModal.searchBox.backToKeywordSearchButtonAriaLabel": {
+    "message": "Back to keyword search",
+    "description": "The ARIA label for back to keyword search button"
+  },
+  "theme.SearchModal.startScreen.recentConversationsTitle": {
+    "message": "Recent conversations",
+    "description": "The title for recent conversations"
+  },
+  "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
+    "message": "Remove this conversation from history",
+    "description": "The title for remove recent conversation button"
+  },
+  "theme.SearchModal.resultsScreen.askAiPlaceholder": {
+    "message": "Ask AI: ",
+    "description": "The placeholder text for Ask AI input"
+  },
+  "theme.SearchModal.askAiScreen.disclaimerText": {
+    "message": "Answers are generated with AI which can make mistakes. Verify responses.",
+    "description": "The disclaimer text for AI answers"
+  },
+  "theme.SearchModal.askAiScreen.relatedSourcesText": {
+    "message": "Related sources",
+    "description": "The text for related sources"
+  },
+  "theme.SearchModal.askAiScreen.thinkingText": {
+    "message": "Thinking...",
+    "description": "The text when AI is thinking"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonText": {
+    "message": "Copy",
+    "description": "The text for copy button"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonCopiedText": {
+    "message": "Copied!",
+    "description": "The text for copy button when copied"
+  },
+  "theme.SearchModal.askAiScreen.copyButtonTitle": {
+    "message": "Copy",
+    "description": "The title for copy button"
+  },
+  "theme.SearchModal.askAiScreen.likeButtonTitle": {
+    "message": "Like",
+    "description": "The title for like button"
+  },
+  "theme.SearchModal.askAiScreen.dislikeButtonTitle": {
+    "message": "Dislike",
+    "description": "The title for dislike button"
+  },
+  "theme.SearchModal.askAiScreen.thanksForFeedbackText": {
+    "message": "Thanks for your feedback!",
+    "description": "The text for thanks for feedback"
+  },
+  "theme.SearchModal.askAiScreen.preToolCallText": {
+    "message": "Searching...",
+    "description": "The text before tool call"
+  },
+  "theme.SearchModal.askAiScreen.duringToolCallText": {
+    "message": "Searching for ",
+    "description": "The text during tool call"
+  },
+  "theme.SearchModal.askAiScreen.afterToolCallText": {
+    "message": "Searched for",
+    "description": "The text after tool call"
+  },
+  "theme.SearchModal.footer.submitQuestionText": {
+    "message": "Submit question",
+    "description": "The submit question text for footer"
+  },
+  "theme.SearchModal.footer.backToSearchText": {
+    "message": "Back to search",
+    "description": "The back to search text for footer"
   }
 }

--- a/docs/i18n/zh/docusaurus-plugin-content-docs/current.json
+++ b/docs/i18n/zh/docusaurus-plugin-content-docs/current.json
@@ -122,5 +122,29 @@
   "sidebar.documentationSidebar.category.Client Components": {
     "message": "客户端组件",
     "description": "The label for category Client Components in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.AI Tooling": {
+    "message": "AI Tooling",
+    "description": "The label for category AI Tooling in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Kotlin DSL": {
+    "message": "Kotlin DSL",
+    "description": "The label for category Kotlin DSL in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Spring": {
+    "message": "Spring",
+    "description": "The label for category Spring in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Webswing": {
+    "message": "Webswing",
+    "description": "The label for category Webswing in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.Security": {
+    "message": "Security",
+    "description": "The label for category Security in sidebar documentationSidebar"
+  },
+  "sidebar.documentationSidebar.category.security-architecture": {
+    "message": "Architecture",
+    "description": "The label for category Architecture in sidebar documentationSidebar"
   }
 }

--- a/docs/i18n/zh/docusaurus-theme-classic/navbar.json
+++ b/docs/i18n/zh/docusaurus-theme-classic/navbar.json
@@ -62,5 +62,9 @@
   "item.label.Contact us": {
     "message": "联系我们",
     "description": "Navbar item with label Contact us"
+  },
+  "item.label.vlatest": {
+    "message": "vlatest",
+    "description": "Navbar item with label vlatest"
   }
 }

--- a/docs/src/components/DocsTools/DocChip.js
+++ b/docs/src/components/DocsTools/DocChip.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { jsx, css } from '@emotion/react';
 import { Tooltip, Chip } from '@mui/material';
-
+import Translate, { translate } from '@docusaurus/Translate';
 import BiotechIcon from '@mui/icons-material/Biotech';
 import AddTaskIcon from '@mui/icons-material/AddTask';
 import FiberSmartRecordIcon from '@mui/icons-material/FiberSmartRecord';
@@ -12,9 +12,9 @@ import DescriptionIcon from '@mui/icons-material/Description';
 import HourglassTopIcon from '@mui/icons-material/HourglassTop';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
-export default function DocChip( { chip, label, href, exclude, tooltipText, color } ) {
+export default function DocChip({ chip, label, href, exclude, tooltipText, color }) {
 
-  const {siteConfig} = useDocusaurusContext();
+  const { siteConfig } = useDocusaurusContext();
   const webforjVersion = Number(siteConfig.customFields.webforjVersion.split("-")[0]);
 
   const mainStyles = css`
@@ -38,58 +38,104 @@ export default function DocChip( { chip, label, href, exclude, tooltipText, colo
   `
 
   let icon;
-  switch(chip){
+  switch (chip) {
     // A "Shadow DOM" chip
     case 'shadow':
-      tooltipText = "This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.";
+      tooltipText = translate({
+        id: 'chip.tooltipText.shadow',
+        message: 'This component renders with a shadow DOM, an API built into the browser that facilitates encapsulation.',
+        description: 'Hover text for components that render with a shadow DOM (document object model)'
+      });
       href = "/docs/glossary#shadow-dom";
-      label = 'Shadow';
+      label = translate({
+        id: 'chip.label.shadow',
+        message: 'Shadow',
+        description: 'Label to indicate a shadow DOM (document object model)'
+      });
       icon = <FiberSmartRecordIcon css={iconStyles} />;
-    break;
+      break;
     // A "DOM Name" chip
     case 'name':
-      tooltipText="The name of this web component as it appears in the DOM.";
-        if (!(exclude)){
-          const path = "/docs/client-components/";
-          const clientPage = label.replace("dwc-", "");
-          href = path.concat(clientPage);
-        }
+      tooltipText = translate({
+        id: 'chip.tooltipText.name',
+        message: 'The name of this web component as it appears in the DOM.',
+        description: 'Hover text to explain how the web component will appear in the DOM (document object model)'
+      });
+      if (!(exclude)) {
+        const path = "/docs/client-components/";
+        const clientPage = label.replace("dwc-", "");
+        href = path.concat(clientPage);
+      }
       icon = <CodeIcon css={iconStyles} />;
-    break;
+      break;
     // A "Version" chip
     case 'since':
+      let versionText = (
+        <React.Fragment>
+          <Translate
+            id='chip.tooltipText.name'
+            description='Hover text to explain what version of webforJ you need to use the feature.'
+            values={{
+              version: label
+            }}
+          >
+            {'This feature is available for webforJ {version} and higher.'}
+          </Translate>
+        </React.Fragment>
+      );
+      let snapshotText = translate({
+        id: 'chip.tooltipText.webforJ.version.snapshot',
+        message: 'This feature will be available in a future release.',
+        description: 'Hover text to explain this feature is only available in a snapshot version of webforJ.'
+      });
       if (webforjVersion >= Number(label) || isNaN(webforjVersion)) {
-        tooltipText = `This feature is available for webforJ ${label} and higher.`;
+        tooltipText = versionText;
         href = `https://github.com/webforj/webforj/releases/tag/${label}`;
         icon = <AddTaskIcon css={iconStyles} />
       } else {
-        tooltipText = `This feature will be available in a future release.`;
+        tooltipText = snapshotText;
         href = `/docs/configuration/snapshots`;
         icon = <HourglassTopIcon css={iconStyles} />
       }
-    break;
+      break;
     // A "Scoped" chip
     case 'scoped':
-      tooltipText = "This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.";
-      exclude= 'true';
-      label='Scoped';
+      tooltipText = translate({
+        id: 'chip.tooltipText.scoped',
+        message: 'This component uses scoped components, an alternative approach to the shadow DOM, a browser API that enables encapsulation. These components scope their styles to avoid leaks or conflicts instead of relying on the native shadow DOM.',
+        description: 'Hover text to explain this component is scoped, an alternative approach to the shadow DOM (document object model).'
+      });
+      exclude = 'true';
+      label = translate({
+        id: 'chip.label.scoped',
+        message: 'Scoped',
+        description: 'Label to show this component uses scoped components.'
+      });
       icon = <BiotechIcon css={iconStyles} />
-    break;
+      break;
     case 'experimental':
-      tooltipText = "This is an experimental feature and may change in future releases.";
-      exclude= 'true';
-      label='Experimental';
-      icon = <ExperimentIcon css={iconStyles}/>
-    break;
+      tooltipText = translate({
+        id: 'chip.tooltipText.experimental',
+        message: 'This is an experimental feature and may change in future releases.',
+        description: 'Hover text to explain this feature is experimental and subject to change.'
+      });
+      exclude = 'true';
+      label = translate({
+        id: 'chip.label.experimental',
+        message: 'Experimental',
+        description: 'Label to show this component is experimental.'
+      });
+      icon = <ExperimentIcon css={iconStyles} />
+      break;
     default:
       console.warn("Uknown chip type:", chip);
       icon = <DescriptionIcon css={iconStyles} />;
-      exclude= 'true';
+      exclude = 'true';
   }
 
   return (
     <Tooltip title={tooltipText} arrow css={mainStyles} >
-      <Chip className={`doc-chip ${chip.className || ''}`} label={label} component="a" href={ !exclude ? href : null} icon={icon} clickable={!exclude} color={color} target="_blank" />
+      <Chip className={`doc-chip ${chip.className || ''}`} label={label} component="a" href={!exclude ? href : null} icon={icon} clickable={!exclude} color={color} target="_blank" />
     </Tooltip>
   )
 }


### PR DESCRIPTION
This PR will close Issue #843 by wrapping the various labels and text for DocChip inside a translate() function.

Now, when the translation job changes the various message values in the `code.json` files, the displayed text for DocChip will change as well.