### PR TITLE
chore: Arranged the text fields into two columns

### DIFF
--- a/docs/docs/components/fields/text-field.md
+++ b/docs/docs/components/fields/text-field.md
@@ -47,6 +47,7 @@ You can specify the type of the TextField using the `setType()` method. Similarl
 <ComponentDemo 
 path='/webforj/textfield?'
 javaE='https://raw.githubusercontent.com/webforj/webforj-documentation/refs/heads/main/src/main/java/com/webforj/samples/views/fields/textfield/TextFieldView.java'
+height='225px'
 />
 
 ## Field value {#field-value}

--- a/src/main/java/com/webforj/samples/views/fields/textfield/TextFieldView.java
+++ b/src/main/java/com/webforj/samples/views/fields/textfield/TextFieldView.java
@@ -1,28 +1,35 @@
 package com.webforj.samples.views.fields.textfield;
 
+import java.util.List;
+
 import com.webforj.component.Composite;
 import com.webforj.component.field.TextField;
-import com.webforj.component.layout.flexlayout.FlexDirection;
+import com.webforj.component.layout.columnslayout.ColumnsLayout;
+import com.webforj.component.layout.columnslayout.ColumnsLayout.Breakpoint;
+import com.webforj.component.layout.flexlayout.FlexJustifyContent;
 import com.webforj.component.layout.flexlayout.FlexLayout;
-import com.webforj.component.layout.flexlayout.FlexWrap;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
 
 @Route
 @FrameTitle("Text Field Form")
 public class TextFieldView extends Composite<FlexLayout> {
-  private final FlexLayout self = getBoundComponent();
-  private final TextField nameField = new TextField();
-  private final TextField emailField = new TextField();
-  private final TextField telField = new TextField();
-  private final TextField urlField = new TextField();
-  private final TextField searchField = new TextField();
+    private final FlexLayout self = getBoundComponent();
+    private final TextField nameField = new TextField();
+    private final TextField emailField = new TextField();
+    private final TextField telField = new TextField();
+    private final TextField urlField = new TextField();
+    private final TextField searchField = new TextField();
+    private final ColumnsLayout fields = new ColumnsLayout(
+        nameField, emailField, telField, urlField, searchField);
 
   public TextFieldView() {
-    self.setMargin("var(--dwc-space-l)")
-        .setSpacing("var(--dwc-space-l)")
-        .setDirection(FlexDirection.ROW)
-        .setWrap(FlexWrap.WRAP);
+
+    self.setWidth("100vw")
+        .setMargin("var(--dwc-space-l) 0")    
+        .setJustifyContent(FlexJustifyContent.CENTER);
+
+    fields.setBreakpoints(List.of(new Breakpoint(0, 2)));
 
     nameField.setPlaceholder("Name")
         .setType(TextField.Type.TEXT)
@@ -49,6 +56,6 @@ public class TextFieldView extends Composite<FlexLayout> {
         .setLabel("Enter Your Search")
         .setValue("Search...");
 
-    self.add(nameField, emailField, telField, urlField, searchField);
+    self.add(fields);
   }
 }


### PR DESCRIPTION
This PR will close Issue #864 by arranging the components in `TextFieldView` into two columns that also have sufficient padding.

<img width="1049" height="374" alt="textfields" src="https://github.com/user-attachments/assets/5be7054b-6ee6-486d-b240-a4b99fceb387" />
