### PR TITLE
ci: Adds a cheap check-changes job that diffs against the last bot co…

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -2,49 +2,105 @@ name: Update Translations
 
 on:
   schedule:
-    # Run daily at 10am Eastern (3pm UTC during EDT, 2pm UTC during EST)
-    - cron: '0 15 * * *'  # 3pm UTC for Daylight Time
-  workflow_dispatch:  # Manual trigger
+    # Run daily at 23:00 UTC (6pm EST / 7pm EDT — after East Coast business hours).
+    - cron: '0 23 * * *'
+  workflow_dispatch:
     inputs:
       target_language:
         description: 'Target language code (e.g., es, de, fr)'
         required: false
         default: 'all'
         type: string
+      force:
+        description: 'Run even if no relevant changes are detected since the last bot commit'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
+  check-changes:
+    name: Check for translation-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history so we can diff against the last bot commit.
+
+      - name: Detect changes since last translation run
+        id: check
+        env:
+          ACTOR_EMAIL: ${{ secrets.ACTOR_EMAIL }}
+        run: |
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            echo "Force flag set - running regardless of detected changes."
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          LAST_BOT_SHA=$(git log -1 --author="$ACTOR_EMAIL" --format=%H || true)
+          if [ -z "$LAST_BOT_SHA" ]; then
+            echo "No prior bot commit found - running to establish a baseline."
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "Last bot commit: $LAST_BOT_SHA"
+
+          # Limit to paths that actually affect what the translator produces.
+          # Everything else (blog, static assets, Java samples, workflows, etc.)
+          # is intentionally ignored.
+          CHANGED=$(git diff --name-only "$LAST_BOT_SHA" HEAD -- \
+            docs/src/ \
+            docs/docs/ \
+            docs/i18n/en/ \
+            docs/docusaurus.config.ts \
+            docs/docusaurus.config.js \
+            docs/sidebars.ts \
+            docs/sidebars.js \
+            .github/.styles/config/vocabularies/webforj/accept.txt)
+
+          if [ -z "$CHANGED" ]; then
+            echo "::notice::No translation-relevant changes since last bot commit - skipping."
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          else
+            echo "Detected translation-relevant changes:"
+            echo "$CHANGED"
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          fi
+
   translate:
     name: Run Translation Tool
+    needs: check-changes
+    if: needs.check-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACTOR_TOKEN }}
-        
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '25.1.0'
           cache: 'npm'
           cache-dependency-path: 'docs/package-lock.json'
-          
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '21'
 
-      - name: Set up Maven
-        uses: stCarolas/setup-maven@v5
+      - name: Cache Docusaurus build state
+        uses: actions/cache@v4
         with:
-          maven-version: 3.9.9
+          path: docs/.docusaurus
+          key: docusaurus-${{ hashFiles('docs/docusaurus.config.ts', 'docs/src/**', 'docs/docs/**', 'docs/package-lock.json') }}
+          restore-keys: |
+            docusaurus-
 
       - name: Install Node.js dependencies
         working-directory: ./docs
         run: npm ci
-        
+
       - name: Generate translation files
         working-directory: ./docs
         run: |
@@ -53,32 +109,49 @@ jobs:
           else
             npm run write-translations -- --locale ${{ github.event.inputs.target_language }}
           fi
-          
+
       - name: Generate heading IDs
         working-directory: ./docs
         run: npm run write-heading-ids
-        
+
       - name: Run custom translation tool
         id: translate
         working-directory: ./docs
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
-          npm run translate
-          EXIT_CODE=$?
-          if [ $EXIT_CODE -eq 1 ]; then
+          # The translator exits 1 when there is nothing to translate, 0 when it
+          # produced changes. Treat any non-zero exit as "no changes" the same
+          # way the previous version did.
+          if npm run translate; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
             echo "No translations needed - skipping build and commit"
             echo "::notice::No translations were needed. All content is up to date."
             echo "has_changes=false" >> $GITHUB_OUTPUT
-          else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
-        
+
+      # JDK + Maven are only needed for the test build below, which only runs
+      # when the translator produced changes. Setting them up conditionally
+      # avoids paying their install cost on no-op runs.
+      - name: Set up JDK 21
+        if: steps.translate.outputs.has_changes == 'true'
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Set up Maven
+        if: steps.translate.outputs.has_changes == 'true'
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.9
+
       - name: Test build with Maven
         if: steps.translate.outputs.has_changes == 'true'
         id: maven-build
         run: mvn clean package -Pprod
-        
+
       - name: Upload translation files on failure
         if: failure() && steps.maven-build.outcome == 'failure'
         uses: actions/upload-artifact@v4
@@ -87,14 +160,13 @@ jobs:
           path: docs/i18n/
           retention-days: 5
           compression-level: 9
-        
+
       - name: Commit and push translation updates
         if: steps.translate.outputs.has_changes == 'true'
         run: |
           git config --local user.email "${{ secrets.ACTOR_EMAIL }}"
           git config --local user.name "${{ secrets.ACTOR_NAME }}"
-          
-          # Check if there are changes to commit
+
           if [ -n "$(git status --porcelain)" ]; then
             git add .
             git commit -m "chore: update translations"


### PR DESCRIPTION
…mmit and skips the translate job entirely when no translation-relevant paths have changed. Drops empty cron runs from ~13 min to ~30 s while preserving full-pipeline behavior on days with real work to do. Also moves the cron to end-of-day, gates Java/Maven setup behind has_changes, and caches docs/.docusaurus for faster boot.