### PR TITLE
fix: Iterate job tool for each language

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -105,9 +105,15 @@ jobs:
         working-directory: ./docs
         run: |
           if [ "${{ github.event.inputs.target_language }}" = "all" ] || [ -z "${{ github.event.inputs.target_language }}" ]; then
-            npm run write-translations
+            npx docusaurus write-translations -- --locale en
+            npx docusaurus write-translations -- --locale es
+            npx docusaurus write-translations -- --locale de
+            npx docusaurus write-translations -- --locale fr
+            npx docusaurus write-translations -- --locale nl
+            npx docusaurus write-translations -- --locale fi
+            npx docusaurus write-translations -- --locale zh
           else
-            npm run write-translations -- --locale ${{ github.event.inputs.target_language }}
+            npx docusaurus write-translations -- --locale ${{ github.event.inputs.target_language }}
           fi
 
       - name: Generate heading IDs

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -105,15 +105,11 @@ jobs:
         working-directory: ./docs
         run: |
           if [ "${{ github.event.inputs.target_language }}" = "all" ] || [ -z "${{ github.event.inputs.target_language }}" ]; then
-            npx docusaurus write-translations -- --locale en
-            npx docusaurus write-translations -- --locale es
-            npx docusaurus write-translations -- --locale de
-            npx docusaurus write-translations -- --locale fr
-            npx docusaurus write-translations -- --locale nl
-            npx docusaurus write-translations -- --locale fi
-            npx docusaurus write-translations -- --locale zh
+            for language in en es de fr nl fi zh; do
+              npm run write-translations -- --locale $language
+            done
           else
-            npx docusaurus write-translations -- --locale ${{ github.event.inputs.target_language }}
+            npm run write-translations -- --locale ${{ github.event.inputs.target_language }}
           fi
 
       - name: Generate heading IDs


### PR DESCRIPTION
This PR will resolve Issue #978.

`npm run write-translations` only creates translations tokens for one language at a time. This PR runs the command for each available language.  