### PR TITLE
refactor: Removed the expand table button by making the table wrapper interactive

### DIFF
--- a/docs/src/components/DocsTools/TableWrapper/TableWrapper.module.css
+++ b/docs/src/components/DocsTools/TableWrapper/TableWrapper.module.css
@@ -1,0 +1,13 @@
+.tableWrapper {
+  position: relative !important;
+  margin-bottom: 2rem !important;
+  max-width: fit-content !important;
+}
+
+.tableWrapper:hover,
+.tableWrapper:focus-visible {
+  box-shadow: var(--dwc-focus-ring-primary);
+  border-radius: var(--dwc-border-radius-m);
+  outline: none;
+  cursor: zoom-in;
+}

--- a/docs/src/components/DocsTools/TableWrapper/index.js
+++ b/docs/src/components/DocsTools/TableWrapper/index.js
@@ -6,7 +6,7 @@ import IconButton from '@mui/material/IconButton';
 import CloseIcon from '@mui/icons-material/Close';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
 import Tooltip from '@mui/material/Tooltip';
-import Box from '@mui/material/Box';
+import styles from './TableWrapper.module.css';
 
 
 export default function TableWrapper({ children, title, ...props }) {
@@ -15,11 +15,18 @@ export default function TableWrapper({ children, title, ...props }) {
 
     const tableRef = useRef(null);
 
-    const handleClickOpen = () => {
+    const handleOpen = () => {
         setOpen(true);
     };
 
-    const handleClose = () => {
+    const handleKeyDown = (e) => {
+        if (e.key === 'Enter') {
+            handleOpen();
+        }
+    };
+
+    const handleClose = (e) => {
+        e.stopPropagation();
         setOpen(false);
     };
 
@@ -32,7 +39,7 @@ export default function TableWrapper({ children, title, ...props }) {
             color: 'var(--ifm-color-primary-lightest)',
             border: '1px solid var(--ifm-color-primary-lightest)',
         },
-          '&:focus': {
+        '&:focus': {
             color: 'var(--ifm-color-primary-lightest)',
             border: '1px solid var(--ifm-color-primary-lightest)',
         }
@@ -51,28 +58,13 @@ export default function TableWrapper({ children, title, ...props }) {
     }, [title]);
 
     return (
-        <div className="table-wrapper" ref={tableRef} style={{ position: 'relative', marginBottom: '2rem', maxWidth: 'fit-content' }}>
-            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
-                <IconButton
-                    onClick={handleClickOpen}
-                    size="small"
-                    aria-label="Expand table"
-                    sx={{
-                        ...iconButtonSx,
-                        disableRipple: true,
-                        gap: '4px',
-                        paddingLeft: '8px',
-                        paddingRight: '8px',
-                        fontSize: '0.75rem',
-                        fontWeight: 600,
-                        letterSpacing: '0.05em',
-                        textTransform: 'uppercase',
-                    }}
-                >
-                    <OpenInFullIcon fontSize="small" />
-                    Expand
-                </IconButton>
-            </Box>
+        <div tabindex="0"
+            className={styles.tableWrapper}
+            ref={tableRef}
+            role="button"
+            onClick={handleOpen}
+            onKeyDown={handleKeyDown}
+            aria-label="Expand table">
 
             <div className="table-container" style={{ overflowX: 'auto' }}>
                 <table {...props}>


### PR DESCRIPTION
This PR will close Issue #810 by making the tables react in a similar behavior as images do on the vs code documentation
https://code.visualstudio.com/docs/editing/getting-started