### PR TITLE
feat: add missing kotlin table views

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <webforj.version>26.01-SNAPSHOT</webforj.version>
+    <webforj.version>26.00-SNAPSHOT</webforj.version>
     <warFileName>${project.artifactId}-${project.version}</warFileName>
     <jetty.version>12.1.2</jetty.version>
     <playwright.version>1.50.0</playwright.version>

--- a/src/main/kotlin/com/webforj/samples/views/table/TableColumnGroupOrderingKotlinView.kt
+++ b/src/main/kotlin/com/webforj/samples/views/table/TableColumnGroupOrderingKotlinView.kt
@@ -1,0 +1,50 @@
+package com.webforj.samples.views.table
+
+import com.webforj.component.Composite
+import com.webforj.component.html.elements.Div
+import com.webforj.component.table.Column
+import com.webforj.component.table.ColumnGroup
+import com.webforj.kotlin.dsl.component.table.table
+import com.webforj.kotlin.extension.vh
+import com.webforj.kotlin.extension.vw
+import com.webforj.router.annotation.FrameTitle
+import com.webforj.router.annotation.Route
+
+@Route
+@FrameTitle("Table Column Group Ordering")
+class TableColumnGroupOrderingKotlinView : Composite<Div>() {
+  private val self = boundComponent
+
+  init {
+    self.apply {
+      table<MusicRecord> {
+        repository = Service.getMusicRecords()
+        width = 100.vw
+        height = 100.vh
+        isStriped = true
+
+        addColumn("Number", MusicRecord::getNumber).apply { minWidth = 70f }
+        addColumn("Title", MusicRecord::getTitle).apply { minWidth = 120f }
+        addColumn("Artist", MusicRecord::getArtist).apply { minWidth = 120f }
+        addColumn("Genre", MusicRecord::getMusicType).apply { minWidth = 80f }
+        addColumn("Label", MusicRecord::getLabel).apply { minWidth = 80f }
+        addColumn("Cost") { String.format("$%.2f", it.cost) }.apply {
+          alignment = Column.Alignment.RIGHT
+          minWidth = 70f
+        }
+
+        setColumnsToAutoFit()
+
+        val music = ColumnGroup.of("music", "Music")
+          .add("Title")
+          .add("Artist")
+          .add("Genre")
+
+        val pricing = ColumnGroup.of("pricing", "Pricing")
+          .add("Cost")
+
+        columnGroups = listOf(music, pricing)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/webforj/samples/views/table/TableColumnGroupsKotlinView.kt
+++ b/src/main/kotlin/com/webforj/samples/views/table/TableColumnGroupsKotlinView.kt
@@ -1,0 +1,48 @@
+package com.webforj.samples.views.table
+
+import com.webforj.component.Composite
+import com.webforj.component.html.elements.Div
+import com.webforj.component.table.Column
+import com.webforj.component.table.ColumnGroup
+import com.webforj.kotlin.dsl.component.table.table
+import com.webforj.kotlin.extension.vh
+import com.webforj.kotlin.extension.vw
+import com.webforj.router.annotation.FrameTitle
+import com.webforj.router.annotation.Route
+
+@Route
+@FrameTitle("Table Column Groups")
+class TableColumnGroupsKotlinView : Composite<Div>() {
+  private val self = boundComponent
+
+  init {
+    self.apply {
+      table<MusicRecord> {
+        repository = Service.getMusicRecords()
+        width = 100.vw
+        height = 100.vh
+        isStriped = true
+
+        addColumn("Title", MusicRecord::getTitle).apply { minWidth = 120f }
+        addColumn("Artist", MusicRecord::getArtist).apply { minWidth = 120f }
+        addColumn("Genre", MusicRecord::getMusicType).apply { minWidth = 80f }
+        addColumn("Cost") { String.format("$%.2f", it.cost) }.apply {
+          alignment = Column.Alignment.RIGHT
+          minWidth = 70f
+        }
+
+        setColumnsToAutoFit()
+
+        val catalog = ColumnGroup.of("catalog", "Catalog")
+          .add("Title")
+          .add("Artist")
+          .add("Genre")
+
+        val pricing = ColumnGroup.of("pricing", "Pricing")
+          .add("Cost")
+
+        columnGroups = listOf(catalog, pricing)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/webforj/samples/views/table/TableHiddenColumnGroupsKotlinView.kt
+++ b/src/main/kotlin/com/webforj/samples/views/table/TableHiddenColumnGroupsKotlinView.kt
@@ -1,0 +1,78 @@
+package com.webforj.samples.views.table
+
+import com.webforj.component.Composite
+import com.webforj.component.button.ButtonTheme
+import com.webforj.component.html.elements.Div
+import com.webforj.component.layout.flexlayout.FlexDirection
+import com.webforj.component.table.Column
+import com.webforj.component.table.ColumnGroup
+import com.webforj.component.table.Table
+import com.webforj.kotlin.dsl.component.button.button
+import com.webforj.kotlin.dsl.component.layout.flexlayout.flexLayout
+import com.webforj.kotlin.dsl.component.table.table
+import com.webforj.kotlin.extension.set
+import com.webforj.kotlin.extension.styles
+import com.webforj.kotlin.extension.vh
+import com.webforj.kotlin.extension.vw
+import com.webforj.router.annotation.FrameTitle
+import com.webforj.router.annotation.Route
+
+@Route
+@FrameTitle("Table Hidden Columns in Groups")
+class TableHiddenColumnGroupsKotlinView : Composite<Div>() {
+  private val self = boundComponent
+  private lateinit var table: Table<MusicRecord>
+  private lateinit var retailColumn: Column<MusicRecord, *>
+
+  init {
+    self.apply {
+      flexLayout {
+        direction = FlexDirection.COLUMN
+        height = 100.vh
+
+        table = table<MusicRecord> {
+          repository = Service.getMusicRecords()
+          width = 100.vw
+          isStriped = true
+
+          addColumn("Title", MusicRecord::getTitle).apply { minWidth = 120f }
+          addColumn("Artist", MusicRecord::getArtist).apply { minWidth = 120f }
+          addColumn("Genre", MusicRecord::getMusicType).apply { minWidth = 80f }
+          addColumn("Cost") { String.format("$%.2f", it.cost) }.apply {
+            alignment = Column.Alignment.RIGHT
+            minWidth = 70f
+          }
+          retailColumn = addColumn("Retail") { String.format("$%.2f", it.retail) }.apply {
+            alignment = Column.Alignment.RIGHT
+            minWidth = 70f
+          }
+
+          setColumnsToAutoFit()
+
+          retailColumn.isHidden = true
+
+          val catalog = ColumnGroup.of("catalog", "Catalog")
+            .add("Title")
+            .add("Artist")
+            .add("Genre")
+
+          val pricing = ColumnGroup.of("pricing", "Pricing")
+            .add("Cost")
+            .add("Retail")
+
+          columnGroups = listOf(catalog, pricing)
+        }
+
+        button("Toggle Retail Column", ButtonTheme.PRIMARY) {
+          maxWidth = "200px"
+          styles["margin-top"] = "1rem"
+          styles["margin-left"] = "1rem"
+          onClick {
+            retailColumn.isHidden = !retailColumn.isHidden
+            table.refreshColumns()
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/webforj/samples/views/table/TableHiddenColumnGroupsKotlinView.kt
+++ b/src/main/kotlin/com/webforj/samples/views/table/TableHiddenColumnGroupsKotlinView.kt
@@ -10,6 +10,8 @@ import com.webforj.component.table.Table
 import com.webforj.kotlin.dsl.component.button.button
 import com.webforj.kotlin.dsl.component.layout.flexlayout.flexLayout
 import com.webforj.kotlin.dsl.component.table.table
+import com.webforj.kotlin.extension.px
+import com.webforj.kotlin.extension.rem
 import com.webforj.kotlin.extension.set
 import com.webforj.kotlin.extension.styles
 import com.webforj.kotlin.extension.vh
@@ -30,6 +32,15 @@ class TableHiddenColumnGroupsKotlinView : Composite<Div>() {
         direction = FlexDirection.COLUMN
         height = 100.vh
 
+        button("Toggle Retail Column", ButtonTheme.PRIMARY) {
+          maxWidth = 200.px
+          styles["margin-top"] = 1.rem
+          styles["margin-left"] = 1.rem
+          onClick {
+            retailColumn.isHidden = !retailColumn.isHidden
+            table.refreshColumns()
+          }
+        }
         table = table<MusicRecord> {
           repository = Service.getMusicRecords()
           width = 100.vw
@@ -61,16 +72,6 @@ class TableHiddenColumnGroupsKotlinView : Composite<Div>() {
             .add("Retail")
 
           columnGroups = listOf(catalog, pricing)
-        }
-
-        button("Toggle Retail Column", ButtonTheme.PRIMARY) {
-          maxWidth = "200px"
-          styles["margin-top"] = "1rem"
-          styles["margin-left"] = "1rem"
-          onClick {
-            retailColumn.isHidden = !retailColumn.isHidden
-            table.refreshColumns()
-          }
         }
       }
     }

--- a/src/main/kotlin/com/webforj/samples/views/table/TableNestedColumnGroupsKotlinView.kt
+++ b/src/main/kotlin/com/webforj/samples/views/table/TableNestedColumnGroupsKotlinView.kt
@@ -1,0 +1,55 @@
+package com.webforj.samples.views.table
+
+import com.webforj.component.Composite
+import com.webforj.component.html.elements.Div
+import com.webforj.component.table.Column
+import com.webforj.component.table.ColumnGroup
+import com.webforj.kotlin.dsl.component.table.table
+import com.webforj.kotlin.extension.vh
+import com.webforj.kotlin.extension.vw
+import com.webforj.router.annotation.FrameTitle
+import com.webforj.router.annotation.Route
+
+@Route
+@FrameTitle("Table Nested Column Groups")
+class TableNestedColumnGroupsKotlinView : Composite<Div>() {
+  private val self = boundComponent
+
+  init {
+    self.apply {
+      table<MusicRecord> {
+        repository = Service.getMusicRecords()
+        width = 100.vw
+        height = 100.vh
+        isStriped = true
+
+        addColumn("Title", MusicRecord::getTitle).apply { minWidth = 120f }
+        addColumn("Artist", MusicRecord::getArtist).apply { minWidth = 120f }
+        addColumn("Genre", MusicRecord::getMusicType).apply { minWidth = 80f }
+        addColumn("Tracks", MusicRecord::getNumberOfTracks).apply { minWidth = 60f }
+        addColumn("Playing Time", MusicRecord::getPlayingTime).apply { minWidth = 80f }
+        addColumn("Cost") { String.format("$%.2f", it.cost) }.apply {
+          alignment = Column.Alignment.RIGHT
+          minWidth = 70f
+        }
+        addColumn("Retail") { String.format("$%.2f", it.retail) }.apply {
+          alignment = Column.Alignment.RIGHT
+          minWidth = 70f
+        }
+
+        setColumnsToAutoFit()
+
+        val catalog = ColumnGroup.of("catalog", "Catalog")
+          .add("Title")
+          .add("Artist")
+          .add("Genre")
+
+        val details = ColumnGroup.of("details", "Details")
+          .add(ColumnGroup.of("media", "Media").add("Tracks").add("Playing Time"))
+          .add(ColumnGroup.of("pricing", "Pricing").add("Cost").add("Retail"))
+
+        columnGroups = listOf(catalog, details)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/webforj/samples/views/table/TablePinnedColumnGroupsKotlinView.kt
+++ b/src/main/kotlin/com/webforj/samples/views/table/TablePinnedColumnGroupsKotlinView.kt
@@ -1,0 +1,53 @@
+package com.webforj.samples.views.table
+
+import com.webforj.component.Composite
+import com.webforj.component.html.elements.Div
+import com.webforj.component.table.Column
+import com.webforj.component.table.ColumnGroup
+import com.webforj.kotlin.dsl.component.table.table
+import com.webforj.kotlin.extension.vh
+import com.webforj.kotlin.extension.vw
+import com.webforj.router.annotation.FrameTitle
+import com.webforj.router.annotation.Route
+
+@Route
+@FrameTitle("Table Pinned Column Groups")
+class TablePinnedColumnGroupsKotlinView : Composite<Div>() {
+  private val self = boundComponent
+
+  init {
+    self.apply {
+      table<MusicRecord> {
+        repository = Service.getMusicRecords()
+        width = 100.vw
+        height = 100.vh
+        isStriped = true
+
+        addColumn("Number", MusicRecord::getNumber).apply { minWidth = 90f }
+        addColumn("Title", MusicRecord::getTitle).apply { minWidth = 200f }
+        addColumn("Artist", MusicRecord::getArtist).apply { minWidth = 200f }
+        addColumn("Genre", MusicRecord::getMusicType).apply { minWidth = 150f }
+        addColumn("Label", MusicRecord::getLabel).apply { minWidth = 150f }
+        addColumn("Cost") { String.format("$%.2f", it.cost) }.apply {
+          alignment = Column.Alignment.RIGHT
+          minWidth = 100f
+        }
+
+        val identity = ColumnGroup.of("identity", "Identity")
+          .setPinDirection(Column.PinDirection.LEFT)
+          .add("Number")
+          .add("Title")
+
+        val catalog = ColumnGroup.of("catalog", "Catalog")
+          .add("Artist")
+          .add("Genre")
+          .add("Label")
+
+        val pricing = ColumnGroup.of("pricing", "Pricing")
+          .add("Cost")
+
+        columnGroups = listOf(identity, catalog, pricing)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/com/webforj/samples/views/table/TableStyledColumnGroupsKotlinView.kt
+++ b/src/main/kotlin/com/webforj/samples/views/table/TableStyledColumnGroupsKotlinView.kt
@@ -1,0 +1,57 @@
+package com.webforj.samples.views.table
+
+import com.webforj.annotation.StyleSheet
+import com.webforj.component.Composite
+import com.webforj.component.html.elements.Div
+import com.webforj.component.table.Column
+import com.webforj.component.table.ColumnGroup
+import com.webforj.kotlin.dsl.component.table.table
+import com.webforj.kotlin.extension.vh
+import com.webforj.kotlin.extension.vw
+import com.webforj.router.annotation.FrameTitle
+import com.webforj.router.annotation.Route
+
+@StyleSheet("ws://css/table/tablestyledcolumngroups.css")
+@Route
+@FrameTitle("Table Styled Column Groups")
+class TableStyledColumnGroupsKotlinView : Composite<Div>() {
+  private val self = boundComponent
+
+  init {
+    self.apply {
+      table<MusicRecord> {
+        repository = Service.getMusicRecords()
+        width = 100.vw
+        height = 100.vh
+        isStriped = true
+
+        addColumn("Title", MusicRecord::getTitle).apply { minWidth = 120f }
+        addColumn("Artist", MusicRecord::getArtist).apply { minWidth = 120f }
+        addColumn("Genre", MusicRecord::getMusicType).apply { minWidth = 80f }
+        addColumn("Tracks", MusicRecord::getNumberOfTracks).apply { minWidth = 60f }
+        addColumn("Playing Time", MusicRecord::getPlayingTime).apply { minWidth = 80f }
+        addColumn("Cost") { String.format("$%.2f", it.cost) }.apply {
+          alignment = Column.Alignment.RIGHT
+          minWidth = 70f
+        }
+        addColumn("Retail") { String.format("$%.2f", it.retail) }.apply {
+          alignment = Column.Alignment.RIGHT
+          minWidth = 70f
+        }
+
+        setColumnsToAutoFit()
+
+        val catalog = ColumnGroup.of("catalog", "Catalog")
+          .add("Title")
+          .add("Artist")
+          .add("Genre")
+
+        val details = ColumnGroup.of("details", "Details")
+          .add(ColumnGroup.of("media", "Media").add("Tracks").add("Playing Time"))
+          .add(ColumnGroup.of("pricing", "Pricing").add("Cost").add("Retail"))
+
+        columnGroups = listOf(catalog, details)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the missing Kotlin versions of:
- TableColumGroupOrdering
- TableHiddenColumnGroups
- TableNestedColumnGroups
- TablePinnedColumnGroups
- TableStyledColumnGroups