### PR TITLE
990 text and html content

### DIFF
--- a/docs/docs/building-ui/elements.md
+++ b/docs/docs/building-ui/elements.md
@@ -47,10 +47,34 @@ The `Element` component supports the composition of child components. Developers
 
 1. **`add(Component... components)`**: This method allows one or multiple components to be added to an optional `String` which designates a specified slot when used with a Web Component. Omitting the slot will add the component between the HTML tags.
 
-2. **`setHtml(String html)`**: This method takes the `String` passed to the method and injects it as HTML within the component. Depending on the `Element`, this may be rendered in different ways.
+2. **`setText(String text)`**: This method behaves similarly to the `setHtml()` method, but injects literal text into the `Element`.
 
-3. **`setText(String text)`**: This method behaves similarly to the `setHtml()` method, but injects literal text into the `Element`.
+  ```java
+  // Shown as the literal characters "<b>Status: ready</b>"
+  element.setText("<b>Status: ready</b>");
+  ```
 
+  :::note Using the `<html>` tag
+  Earlier versions of webforJ treated a value wrapped in `<html>` and passed to `setText()` as HTML. This behavior is deprecated and will be removed in webforJ 27.00.
+
+  The first time an `<html>` wrapped value reaches `setText()`, a warning is logged that names the component and the call site, so the call can be moved to `setHtml()`.
+
+  To adopt the webforJ 27.00 default ahead of time, set `webforj.legacyHtmlInText` to `false`. In a Spring app, the same value is set through `webforj.legacy-html-in-text`.
+
+  ```java
+  // webforj.legacyHtmlInText = true (default)
+  element.setText("<html><b>Status: ready</b></html>"); // renders bold
+
+  // webforj.legacyHtmlInText = false
+  element.setText("<html><b>Status: ready</b></html>"); // shows the characters <b>Status: ready</b>
+  ```
+  :::
+
+3. **`setHtml(String html)`**: This method takes the `String` passed to the method and injects it as HTML within the component. Depending on the `Element`, this may be rendered in different ways.
+
+  :::danger Cross-site Scripting (XSS)
+  As a precaution against [cross-site scripting (XSS) attacks](/docs/security/application-security/common-threats#cross-site-scripting-xss), only use `setHtml()` with content you directly control.
+  :::
 
 <ComponentDemo
 path='/webforj/elementinputtext'

--- a/docs/docs/building-ui/using-components.md
+++ b/docs/docs/building-ui/using-components.md
@@ -17,7 +17,7 @@ Every component exposes properties that control its content, appearance, and beh
 
 ### Text content {#text-content}
 
-The `setText()` method sets a component's visible text, such as the caption on a `Button` or the content of a `Label`. For input components like `TextField`, use `setValue()` instead to set the field's current value.
+The `setText()` method sets a component's visible text as literal characters, such as the caption on a `Button` or the content of a `Label`. For input components like `TextField`, use `setValue()` instead to set the field's current value.
 
 ```java
 Button button = new Button();
@@ -30,12 +30,41 @@ TextField field = new TextField();
 field.setValue("Initial value");
 ```
 
-Some components also support `setHtml()` for cases where you need inline HTML markup in the content:
+Markup written with `setText()` appears as those characters and is never run, which keeps text that comes from user input or external data from being interpreted as live markup.
+
+```java
+// Shown as the literal characters "<b>Status: ready</b>"
+component.setText("<b>Status: ready</b>");
+```
+
+:::note Using the `<html>` tag
+Earlier versions of webforJ treated a value wrapped in `<html>` and passed to `setText()` as HTML. This behavior is deprecated and will be removed in webforJ 27.00.
+
+The first time an `<html>` wrapped value reaches `setText()`, a warning is logged that names the component and the call site, so the call can be moved to `setHtml()`.
+
+To adopt the webforJ 27.00 default ahead of time, set `webforj.legacyHtmlInText` to `false`. In a Spring app, the same value is set through `webforj.legacy-html-in-text`.
+
+```java
+// webforj.legacyHtmlInText = true (default)
+component.setText("<html><b>Status: ready</b></html>"); // renders bold
+
+// webforj.legacyHtmlInText = false
+component.setText("<html><b>Status: ready</b></html>"); // shows the characters <b>Status: ready</b>
+```
+:::
+
+### Rendering HTML {#rendering-html}
+
+Some components also support `setHtml()` for cases where you need to render inline HTML markup in the content:
 
 ```java
 Div container = new Div();
 container.setHtml("<strong>Bold text</strong> and <em>italic text</em>");
 ```
+
+:::danger Cross-site Scripting (XSS)
+As a precaution against [cross-site scripting (XSS) attacks](/docs/security/application-security/common-threats#cross-site-scripting-xss), only use `setHtml()` with content you directly control.
+:::
 
 ### HTML attributes {#html-attributes}
 

--- a/docs/docs/configuration/overview.md
+++ b/docs/docs/configuration/overview.md
@@ -4,6 +4,7 @@ title: Configuration
 hide_table_of_contents: true
 hide_giscus_comments: true
 description: Configure webforJ apps with properties, deployment options, debugging, licensing, asset minification, and installable app profiles.
+sidebar_class_name: has-new-content
 ---
 
 <Head>

--- a/docs/docs/configuration/properties.md
+++ b/docs/docs/configuration/properties.md
@@ -2,6 +2,7 @@
 title: Property Configuration
 sidebar_position: 30
 description: Set webforJ entry points, debug mode, locales, file upload limits, and servlet mappings through webforj.conf and web.xml.
+sidebar_class_name: updated-content
 ---
 
 # Configuring webforJ properties
@@ -15,8 +16,6 @@ The `webforj.conf` file is a core configuration file in webforJ, specifying app 
 :::tip
 If you are integrating with [Spring](../integrations/spring/overview.md), you can set these `webforj.conf` properties in the `application.properties` file.
 :::
-
-
 
 ### Example `webforj.conf` file {#example-webforjconf-file}
 
@@ -50,6 +49,7 @@ webforj.clientHeartbeatRate = 1s
 | **`webforj.fileUpload.accept`**      | List    | The allowed file types for file uploads. By default, all file types are allowed. Supported formats include MIME types like `image/*`, `application/pdf`, `text/plain`, or file extensions like `*.txt`. When using a standard BBj installation, this setting is disregarded and managed through `fileupload-accept.txt`. | `[]`            |
 | **`webforj.fileUpload.maxSize`**     | Long    | The maximum file size allowed for file uploads, in bytes. By default, there is no limit. When using a standard BBj installation, this setting is disregarded and managed through `fileupload-accept.txt`. | `null`          |
 | **`webforj.iconsDir`**               | String  | URL endpoint for icons directory (default serves from `resources/icons/`). | `icons/` |
+| **`webforj.legacyHtmlInText`**&nbsp;<DocChip chip='since' label='26.01' /> | Boolean | When `true`, a value wrapped in `<html>` renders its content as HTML. When `false`, the same value is shown literally. | `true` |
 | **`webforj.license.cfg`**            | String  | The directory for the license configuration. By default, it's the same as the webforJ configuration directory, but this can be customized if needed. | `"."`  |
 | **`webforj.license.startupTimeout`** | Integer | License startup timeout in seconds. | `null` |
 | **`webforj.locale`**                 | String  | The locale for the app, determining language, region settings, and formats for dates, times, and numbers. | `null` |

--- a/docs/docs/upgrading/_category_.json
+++ b/docs/docs/upgrading/_category_.json
@@ -5,5 +5,5 @@
     "type": "doc",
     "id": "overview"
   },
-  "className": "cat-icon cat-icon--upgrading"
+  "className": "has-new-content cat-icon cat-icon--upgrading"
 }

--- a/docs/docs/upgrading/automated-upgrades.md
+++ b/docs/docs/upgrading/automated-upgrades.md
@@ -65,4 +65,5 @@ After running OpenRewrite with a webforJ recipe and resolving any `TODO` comment
 
 | Version | Standard webforJ Projects | Spring Boot Projects |
 | ------- | ------- | ------- |
+| v26.01 | `com.webforj.rewrite.v26.UpgradeWebforj_26_01` | `com.webforj.rewrite.v26.UpgradeWebforjSpring_26_01` |
 | v26 | `com.webforj.rewrite.v26.UpgradeWebforj` | `com.webforj.rewrite.v26.UpgradeWebforjSpring` |

--- a/docs/docs/upgrading/webforj-25.00.md
+++ b/docs/docs/upgrading/webforj-25.00.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrade to 25.00
 description: Upgrade from 24.00 to 25.00
-sidebar_position: 10
+sidebar_position: 30
 ---
 
 This documentation serves as a guide to upgrade webforJ apps from 24.00 to 25.00.

--- a/docs/docs/upgrading/webforj-26.00/_category_.json
+++ b/docs/docs/upgrading/webforj-26.00/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Upgrade to 26.00",
-  "position": 5,
+  "position": 20,
   "className": "new-content",
   "link": {
     "type": "doc",

--- a/docs/docs/upgrading/webforj-27.00.md
+++ b/docs/docs/upgrading/webforj-27.00.md
@@ -1,0 +1,26 @@
+---
+title: Upgrade to 27.00
+description: Upgrade from 26.00 to 27.00
+sidebar_position: 10
+sidebar_class_name: new-content
+draft: true
+---
+
+This documentation serves as a guide to upgrade webforJ apps from 26.00 to 27.00.
+Here are the changes needed for existing apps to continue running smoothly.
+As always, see the [GitHub release overview](https://github.com/webforj/webforj/releases) for a more comprehensive list of changes between releases.
+
+<!-- INTRO_END -->
+
+<AutomatedUpgradeTip />
+
+## Text and HTML content {#text-and-html-content}
+
+Earlier versions treated a value wrapped in `<html>` and passed to `setText()` as HTML. This behavior is deprecated and is removed in webforJ 27.00. The `webforj.legacyHtmlInText` setting controls it:
+
+- `true` (default): a value wrapped in `<html>` renders its content as HTML.
+- `false`: The same value is shown literally.
+
+The `<html>` wrapper is never displayed in either case.
+
+The first time an `<html>` wrapped value reaches `setText()`, a warning is logged that names the component and the call site, so the call can be moved to `setHtml()`.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <webforj.version>26.00</webforj.version>
+    <webforj.version>26.01-SNAPSHOT</webforj.version>
     <warFileName>${project.artifactId}-${project.version}</warFileName>
     <jetty.version>12.1.2</jetty.version>
     <playwright.version>1.50.0</playwright.version>
@@ -132,6 +132,23 @@
   <build>
     <finalName>${warFileName}</finalName>
     <plugins>
+    <plugin>
+  <groupId>org.openrewrite.maven</groupId>
+  <artifactId>rewrite-maven-plugin</artifactId>
+  <version>6.36.0</version>
+  <configuration>
+    <activeRecipes>
+      <recipe>com.webforj.rewrite.v26.UpgradeWebforj_26_01</recipe>
+    </activeRecipes>
+  </configuration>
+  <dependencies>
+    <dependency>
+      <groupId>com.webforj</groupId>
+      <artifactId>webforj-rewrite</artifactId>
+      <version>26.01-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+</plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <webforj.version>26.01-SNAPSHOT</webforj.version>
+    <webforj.version>26.01</webforj.version>
     <warFileName>${project.artifactId}-${project.version}</warFileName>
     <jetty.version>12.1.2</jetty.version>
     <playwright.version>1.50.0</playwright.version>
@@ -132,23 +132,6 @@
   <build>
     <finalName>${warFileName}</finalName>
     <plugins>
-    <plugin>
-  <groupId>org.openrewrite.maven</groupId>
-  <artifactId>rewrite-maven-plugin</artifactId>
-  <version>6.36.0</version>
-  <configuration>
-    <activeRecipes>
-      <recipe>com.webforj.rewrite.v26.UpgradeWebforj_26_01</recipe>
-    </activeRecipes>
-  </configuration>
-  <dependencies>
-    <dependency>
-      <groupId>com.webforj</groupId>
-      <artifactId>webforj-rewrite</artifactId>
-      <version>26.01-SNAPSHOT</version>
-    </dependency>
-  </dependencies>
-</plugin>
       <plugin>
         <groupId>com.diffplug.spotless</groupId>
         <artifactId>spotless-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <webforj.version>26.01</webforj.version>
+    <webforj.version>26.00</webforj.version>
     <warFileName>${project.artifactId}-${project.version}</warFileName>
     <jetty.version>12.1.2</jetty.version>
     <playwright.version>1.50.0</playwright.version>

--- a/src/main/java/com/webforj/samples/views/button/ButtonView.java
+++ b/src/main/java/com/webforj/samples/views/button/ButtonView.java
@@ -1,7 +1,5 @@
 package com.webforj.samples.views.button;
 
-import static com.webforj.component.optiondialog.OptionDialog.showMessageDialog;
-
 import com.webforj.component.Composite;
 import com.webforj.component.button.Button;
 import com.webforj.component.button.ButtonTheme;
@@ -10,6 +8,7 @@ import com.webforj.component.field.TextField.Type;
 import com.webforj.component.layout.flexlayout.FlexAlignment;
 import com.webforj.component.layout.flexlayout.FlexDirection;
 import com.webforj.component.layout.flexlayout.FlexLayout;
+import com.webforj.component.optiondialog.MessageDialog;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
 
@@ -40,7 +39,8 @@ public class ButtonView extends Composite<FlexLayout> {
             e -> {
               String message =
                   "Welcome to the app %s %s!".formatted(firstName.getText(), lastName.getText());
-              showMessageDialog(message, "Welcome");
+              MessageDialog messageDialog = new MessageDialog(message, "Welcome");
+              messageDialog.setRawText(true).show();
             });
 
     clear =

--- a/src/main/java/com/webforj/samples/views/element/ElementInputEventView.java
+++ b/src/main/java/com/webforj/samples/views/element/ElementInputEventView.java
@@ -1,12 +1,11 @@
 package com.webforj.samples.views.element;
 
-import static com.webforj.component.optiondialog.OptionDialog.showMessageDialog;
-
 import com.webforj.annotation.StyleSheet;
 import com.webforj.component.Composite;
 import com.webforj.component.element.Element;
 import com.webforj.component.element.event.ElementEventOptions;
 import com.webforj.component.html.elements.Div;
+import com.webforj.component.optiondialog.MessageDialog;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
 
@@ -33,7 +32,10 @@ public class ElementInputEventView extends Composite<Div> {
     input.addEventListener(
         "keypress",
         e -> {
-          showMessageDialog(e.getEventMap().get("theValue"), "Input Event");
+          MessageDialog messageDialog =
+              new MessageDialog(e.getEventMap().get("theValue"), "Input Event");
+          messageDialog.setRawText(true);
+          messageDialog.show();
         },
         options);
   }

--- a/src/main/resources/webforj-dev.conf
+++ b/src/main/resources/webforj-dev.conf
@@ -8,3 +8,4 @@ webforj.entry = com.webforj.samples.Application
 webforj.debug = true
 webforj.reloadOnServerError = on
 webforj.clientHeartbeatRate = 1s
+webforj.legacyHtmlInText = false

--- a/src/main/resources/webforj-prod.conf
+++ b/src/main/resources/webforj-prod.conf
@@ -7,3 +7,4 @@ webforj.assetsExt=".html"
 webforj.entry = com.webforj.samples.Application
 webforj.reloadOnServerError = off
 webforj.assetsIndex = [ "index.html", "overview.html" ]
+webforj.legacyHtmlInText = false

--- a/src/test/java/com/webforj/samples/views/button/ButtonViewIT.java
+++ b/src/test/java/com/webforj/samples/views/button/ButtonViewIT.java
@@ -35,4 +35,13 @@ public class ButtonViewIT extends BaseTest {
     assertThat(button.getLastName()).hasValue("");
     assertThat(button.getEmail()).hasValue("");
   }
+
+  @Test
+  public void testLiteralCharacters() {
+    button.getFirstName().fill("<html><b>Jason</b></html>");
+    button.getLastName().fill("<html><b>Turner</b></html>");
+    button.getSubmitButton().click();
+    assertThat(button.getWelcomeDialog())
+        .hasValue("Welcome to the app <html><b>Jason</b></html> <html><b>Turner</b></html>");
+  }
 }

--- a/src/test/java/com/webforj/samples/views/composite/CompositeViewIT.java
+++ b/src/test/java/com/webforj/samples/views/composite/CompositeViewIT.java
@@ -40,4 +40,12 @@ public class CompositeViewIT extends BaseTest {
     Locator radioButtons = page.getByRole(AriaRole.RADIO);
     assertThat(radioButtons.nth(3)).not().isVisible();
   }
+
+  @Test
+  public void testLiteralCharacters() {
+    compositePage.getToDoInput().fill("<html><b>New Task</b></html>");
+    compositePage.getToDoInput().press("Enter");
+    Locator addedItem = page.getByText("<html><b>New Task</b></html>");
+    assertThat(addedItem).isVisible();
+  }
 }

--- a/src/test/java/com/webforj/samples/views/drawer/DrawerTaskViewIT.java
+++ b/src/test/java/com/webforj/samples/views/drawer/DrawerTaskViewIT.java
@@ -44,4 +44,17 @@ public class DrawerTaskViewIT extends BaseTest {
         page.getByRole(AriaRole.CHECKBOX, new Page.GetByRoleOptions().setName("New Task from IT"));
     assertThat(newTaskCheckbox).isVisible();
   }
+
+  @Test
+  public void testLiteralCharacters() {
+    Locator newTaskInput =
+        page.getByRole(
+            AriaRole.TEXTBOX, new Page.GetByRoleOptions().setName("<html><b>New Task</b></html>"));
+
+    Locator addTaskButton =
+        page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Add Task"));
+    addTaskButton.click();
+
+    assertThat(newTaskInput).hasValue("<html><b>New Task</b></html>");
+  }
 }

--- a/src/test/java/com/webforj/samples/views/element/ElementInputEventViewIT.java
+++ b/src/test/java/com/webforj/samples/views/element/ElementInputEventViewIT.java
@@ -26,4 +26,12 @@ public class ElementInputEventViewIT extends BaseTest {
 
     elementInputEventPage.getOKButton().click();
   }
+
+  @Test
+  public void testLiteralCharacters() {
+    elementInputEventPage.getInputField().fill("<html><b>Hello World</b></html>");
+    elementInputEventPage.getOKButton().click();
+    assertThat(elementInputEventPage.getDialogMessage())
+        .hasValue("<html><b>Hello World</b></html>");
+  }
 }

--- a/src/test/java/com/webforj/samples/views/table/TableEditDataViewIT.java
+++ b/src/test/java/com/webforj/samples/views/table/TableEditDataViewIT.java
@@ -27,4 +27,13 @@ public class TableEditDataViewIT extends BaseTest {
 
     assertThat(tablePage.verifyTitle("Somebody I Used To Know")).isVisible();
   }
+
+  @Test
+  public void testLiteralCharacters() {
+    tablePage.getEditButton().click();
+    tablePage.getInput().fill("<html><b>Somebody I Used To Know</b></html>");
+    tablePage.getSaveButton().click();
+
+    assertThat(tablePage.verifyTitle("<html><b>Somebody I Used To Know</b></html>")).isVisible();
+  }
 }


### PR DESCRIPTION
This PR resolves #990 by documenting the new behavior of `setText()` and `setHtml()` added in 26.01

See related PR - https://github.com/webforj/webforj-documentation/pull/1002

@hyyan, here are components that are still displaying old behavior, even when I was running the project on the 26.01 snapshot:

## TextField  in CompositeView
<img width="675" height="355" alt="htmltag4" src="https://github.com/user-attachments/assets/8cfbfbc4-aa22-4b03-86ef-215f577d7ad8" />

[https://docs.webforj.com/docs/building-ui/composite-components#example-composite-component](https://docs.webforj.com/docs/building-ui/composite-components#example-composite-component)

## Table cell  in TitleEditorComponent
<img width="783" height="428" alt="htmltags3" src="https://github.com/user-attachments/assets/afd92db2-ae0a-465e-a49a-b4d36eedc559" />

[https://docs.webforj.com/docs/components/table/refreshing](https://docs.webforj.com/docs/components/table/refreshing)

## Toast in FormValidationView
<img width="510" height="477" alt="htmltags" src="https://github.com/user-attachments/assets/d1af0253-8164-462d-bba6-01514c04706a" />

[https://docs.webforj.com/docs/building-ui/using-components#form-validation](https://docs.webforj.com/docs/building-ui/using-components#form-validation)

## MessageDialog in ButtonView
<img width="481" height="248" alt="htmltags2" src="https://github.com/user-attachments/assets/c7048f30-06b7-4c18-a58d-bd40dc0dd9b5" />

[https://docs.webforj.com/docs/components/button](https://docs.webforj.com/docs/components/button)

### Note
When the MessageDialog was set with a formatted string, it didn't show the literal text, however, for ElementInputEventView it did show as expected:
<img width="541" height="252" alt="image" src="https://github.com/user-attachments/assets/871feb10-1159-44a8-91f7-7b343d45f981" />
