### PR TITLE
feat: add AI writing style checks

### DIFF
--- a/.github/.styles/webforJ/AIArtifacts.yml
+++ b/.github/.styles/webforJ/AIArtifacts.yml
@@ -1,0 +1,14 @@
+extends: existence
+message: "Remove chatbot artifact '%s' left over from pasted AI output."
+link: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing"
+level: error
+ignorecase: true
+tokens:
+  - 'oaicite'
+  - 'oai_citation'
+  - 'contentReference'
+  - 'citationturn'
+  - 'turn\d+search\d+'
+  - 'utm_source='
+  - 'grok_card'
+  - 'attached_file'

--- a/.github/.styles/webforJ/AIDisclaimer.yml
+++ b/.github/.styles/webforJ/AIDisclaimer.yml
@@ -16,3 +16,4 @@ tokens:
   - 'I cannot browse'
   - "I (?:don'?t|do not|cannot) have access to real-time"
   - "I(?:'m| am) unable to provide real-time"
+  - 'let me know'

--- a/.github/.styles/webforJ/AIDisclaimer.yml
+++ b/.github/.styles/webforJ/AIDisclaimer.yml
@@ -1,0 +1,18 @@
+extends: existence
+message: "Remove leftover AI text '%s'. This reads like pasted model output."
+link: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing"
+level: error
+ignorecase: true
+# NOTE: "AI" is an accepted term in the webforj vocabulary, and Vale masks
+# accepted terms from all checks, so phrases containing the bare word "AI"
+# (e.g. "as an AI language model") cannot be matched directly. The
+# "language model" token below recovers that case.
+tokens:
+  - 'language model'
+  - 'as a large language model'
+  - 'as of my last (?:knowledge )?(?:update|training)'
+  - 'knowledge cut-?off'
+  - 'my training data'
+  - 'I cannot browse'
+  - "I (?:don'?t|do not|cannot) have access to real-time"
+  - "I(?:'m| am) unable to provide real-time"

--- a/.github/.styles/webforJ/AIVocab.yml
+++ b/.github/.styles/webforJ/AIVocab.yml
@@ -1,0 +1,12 @@
+extends: existence
+message: "'%s' is a common AI filler word. Use plainer, more specific wording."
+link: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing"
+level: warning
+ignorecase: true
+tokens:
+  - 'delv(?:e|es|ed|ing)'
+  - 'intricate'
+  - 'interplay'
+  - 'tapestry'
+  - 'underscor(?:es|ed|ing)'
+  - 'underscore the'

--- a/.github/.styles/webforJ/Fluff.yml
+++ b/.github/.styles/webforJ/Fluff.yml
@@ -1,7 +1,0 @@
-extends: existence
-message: "Avoid using words like '%s' that don't add value to the content."
-level: warning
-tokens:
-- seamless
-- seamlessly
-- robust

--- a/.github/.styles/webforJ/Hedging.yml
+++ b/.github/.styles/webforJ/Hedging.yml
@@ -1,0 +1,13 @@
+extends: existence
+message: "Avoid hedging/filler like '%s'. Remove it or state the point directly."
+link: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing"
+level: warning
+ignorecase: true
+tokens:
+  - "it(?:'s| is) important to note"
+  - "it(?:'s| is) worth (?:noting|mentioning)"
+  - 'needless to say'
+  - 'at the end of the day'
+  - "in today'?s (?:fast-paced )?(?:world|digital age|era)"
+  - 'in the digital age'
+  - 'when it comes to'

--- a/.github/.styles/webforJ/Parallelism.yml
+++ b/.github/.styles/webforJ/Parallelism.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Avoid the '%s' construction common in AI writing. State it directly."
+link: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing"
+level: suggestion
+ignorecase: true
+raw:
+  - "(?:not only\\b.{1,60}?\\bbut(?: also)?|it(?:'s| is) not\\b.{1,40}?\\bit(?:'s| is))"

--- a/.github/.styles/webforJ/Puffery.yml
+++ b/.github/.styles/webforJ/Puffery.yml
@@ -1,0 +1,27 @@
+extends: existence
+message: "Avoid promotional language like '%s'. State what the feature does plainly."
+link: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing"
+level: warning
+ignorecase: true
+tokens:
+  - 'stands as'
+  - '(?:serves|stands) as a testament'
+  - 'is a testament'
+  - 'plays a (?:vital|crucial|pivotal|key|significant) role'
+  - '(?:leaves?|left) an indelible mark'
+  - 'reflects? a broader'
+  - 'part of a broader'
+  - 'paving the way'
+  - 'boasts'
+  - 'vibrant'
+  - 'profound'
+  - 'nestled'
+  - 'in the heart of'
+  - 'groundbreaking'
+  - 'natural beauty'
+  - 'cutting-edge'
+  - 'state-of-the-art'
+  - 'best-in-class'
+  - 'world-class'
+  - 'game-?changer'
+  - 'game-?changing'

--- a/.github/.styles/webforJ/Puffery.yml
+++ b/.github/.styles/webforJ/Puffery.yml
@@ -25,3 +25,7 @@ tokens:
   - 'world-class'
   - 'game-?changer'
   - 'game-?changing'
+  - 'revolutionary'
+  - 'seamless'
+  - 'seamlessly'
+  - 'robust'

--- a/.github/.styles/webforJ/SmartQuotes.yml
+++ b/.github/.styles/webforJ/SmartQuotes.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: "Use straight quotes/apostrophes instead of the curly character '%s'."
+link: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing"
+level: warning
+nonword: true
+tokens:
+  - '“'
+  - '”'
+  - '‘'
+  - '’'

--- a/.github/.styles/webforJ/SmartQuotes.yml
+++ b/.github/.styles/webforJ/SmartQuotes.yml
@@ -1,10 +1,10 @@
-extends: existence
+extends: substitution
 message: "Use straight quotes/apostrophes instead of the curly character '%s'."
 link: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing"
 level: warning
 nonword: true
-tokens:
-  - '“'
-  - '”'
-  - '‘'
-  - '’'
+action:
+  name: replace
+swap:
+  '(?:“|”)': '"'
+  '(?:‘|’)': "'"

--- a/.github/.styles/webforJ/Weasel.yml
+++ b/.github/.styles/webforJ/Weasel.yml
@@ -1,0 +1,13 @@
+extends: existence
+message: "Vague attribution '%s'. Cite a specific source or remove the claim."
+link: "https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing"
+level: suggestion
+ignorecase: true
+tokens:
+  - 'experts (?:argue|say|believe|agree|note)'
+  - 'studies show'
+  - 'research shows'
+  - 'it is widely (?:believed|regarded|considered|known)'
+  - 'observers (?:note|cite)'
+  - 'industry reports'
+  - 'many believe'


### PR DESCRIPTION
closes #510

@bbrennanbasis  Rules are generated per AI, validate and get it merged once ready.

```
---
title: AI writing rule test fixture
---

# AI writing rule test fixture

This file intentionally contains every pattern the custom webforJ Vale rules
should catch. Run `vale docs/ai-writing-test.md` and confirm each section
produces alerts. It is a test fixture, not real documentation.

## Puffery (webforJ.Puffery, warning)

webforJ stands as the best choice and serves as a testament to good design; it
is a testament to the team. The router plays a vital role and the API plays a
pivotal role. It leaves an indelible mark and left an indelible mark. This
reflects a broader trend and is part of a broader movement, paving the way
forward. The library boasts a vibrant and profound design, nestled in the heart
of the stack, with groundbreaking natural beauty. It is cutting-edge,
state-of-the-art, best-in-class, and world-class: a true game-changer and a
game changing release.

## AI vocabulary (webforJ.AIVocab, warning)

We delve into the topic; she delves deeper; they delved in; we are delving now.
The intricate interplay of parts underscores the value, underscored the design,
and keeps underscoring the goal. This will underscore the point. It is woven
into a rich tapestry.

## Hedging and filler (webforJ.Hedging, warning)

It's important to note that this works. It is worth noting the limits, and it's
worth mentioning the rest. Needless to say, it ships. At the end of the day it
runs. In today's fast-paced world and in the digital age, when it comes to
performance, it is fine.

## Negative parallelism (webforJ.Parallelism, suggestion)

This is not only fast but also reliable. It's not slow, it's quick.

## AI disclaimer leaks (webforJ.AIDisclaimer, error)

As a large language model, I cannot help. Speaking as a language model here.
As of my last update in 2023, and as of my last knowledge update, my training
data ends there. My knowledge cutoff applies. I cannot browse the web. I don't
have access to real-time data and I'm unable to provide real-time results.

## Chatbot artifacts (webforJ.AIArtifacts, error)

See :contentReference[oaicite:1]{index=1} and the oai_citation note. The
citationturn0search0 marker and turn0search5 appear. Link with
utm_source=chatgpt.com, plus grok_card and attached_file leftovers.

## Vague attribution (webforJ.Weasel, suggestion)

Experts argue this is best, and studies show it works; research shows the same.
It is widely believed to be safe. Observers note the trend, industry reports
agree, and many believe it.

## Smart quotes (webforJ.SmartQuotes, warning)

He said “hello” and ‘goodbye’ and it’s done.

## Em dash overuse (webforJ.EmDashesDocument, warning; webforJ.EmDashes in summary)

One—two—three—four em dashes in a single sentence should trip the cap.
```