### PR TITLE
chore: AppLayout Drawer opened on all screens for AppNav samples

### DIFF
--- a/src/main/java/com/webforj/samples/views/appnav/AppNavPinningView.java
+++ b/src/main/java/com/webforj/samples/views/appnav/AppNavPinningView.java
@@ -35,6 +35,7 @@ public class AppNavPinningView extends Composite<AppLayout> {
 
   private void setDrawer() {
     self.addToDrawer(appNav);
+    self.setDrawerBreakpoint("0px");
 
     AppNavItem dashboard = createItem("Dashboard", "layout-dashboard");
     dashboard.setPinned(true); // starts in the Favorites group

--- a/src/main/java/com/webforj/samples/views/appnav/AppNavSearchView.java
+++ b/src/main/java/com/webforj/samples/views/appnav/AppNavSearchView.java
@@ -45,6 +45,7 @@ public class AppNavSearchView extends Composite<AppLayout> {
 
   private void setDrawer() {
     self.addToDrawer(appNav);
+    self.setDrawerBreakpoint("0px");
 
     AppNavItem dashboard = createItem("Dashboard", "layout-dashboard");
     dashboard.setPinned(true); // stays visible while searching

--- a/src/main/java/com/webforj/samples/views/appnav/AppNavView.java
+++ b/src/main/java/com/webforj/samples/views/appnav/AppNavView.java
@@ -35,6 +35,7 @@ public class AppNavView extends Composite<AppLayout> {
 
   private void setDrawer() {
     self.addToDrawer(appNav);
+    self.setDrawerBreakpoint("0px");
 
     AppNavItem inbox =
         new AppNavItem("Inbox")


### PR DESCRIPTION
This PR keeps the drawers open for the [AppNav](https://docs.webforj.com/docs/components/appnav) examples, even on smaller screens, so the component being documented isn't hidden behind an action on smaller screens.

## Before
<img width="1020" height="767" alt="before" src="https://github.com/user-attachments/assets/02ac9395-16b0-4ad1-8c97-d8d137b596cd" />

## After
<img width="1012" height="772" alt="after" src="https://github.com/user-attachments/assets/5b2d2a85-3832-4dd4-a073-6c9ed6f7f2f4" />
