### PR TITLE
chore: remove next and previous links on the cookbook overview

### DIFF
--- a/docs/cookbook/index.mdx
+++ b/docs/cookbook/index.mdx
@@ -4,6 +4,8 @@ description: Ready-to-use code snippets for common webforJ tasks.
 sidebar_position: 1
 hide_table_of_contents: true
 hide_giscus_comments: true
+pagination_prev: null
+pagination_next: null
 ---
 
 import CookbookIndex from '@site/src/components/Cookbook/CookbookIndex';


### PR DESCRIPTION
This PR will close Issue #1027.