### PR TITLE
style: Put ButtonThemesView buttons in ColumnLayout containers

### DIFF
--- a/docs/docs/components/button.md
+++ b/docs/docs/components/button.md
@@ -109,7 +109,7 @@ Shown below are example buttons with each of the supported Themes applied: <br/>
 <ComponentDemo
 path='/webforj/buttonthemes'
 files={['src/main/java/com/webforj/samples/views/button/ButtonThemesView.java']}
-height='175px'
+height='350px'
 />
 
 ### Expanses {#expanses}

--- a/src/main/frontend/css/button/buttonThemes.css
+++ b/src/main/frontend/css/button/buttonThemes.css
@@ -1,0 +1,25 @@
+.buttonWrapperWidth {
+  width: 632px;
+  overflow: hidden;
+}
+
+@media (width < 712px) {
+.buttonWrapperWidth {
+  width: 416px;
+}
+}
+
+@media (width < 560px) {
+.buttonWrapperWidth {
+  width: 208px;
+}
+}
+
+@media (width > 1464px) {
+.buttonWrapperWidth {
+  width: 1464px;
+}
+dwc-icon-button {
+  display: none;
+}
+}

--- a/src/main/java/com/webforj/samples/views/button/ButtonThemesView.java
+++ b/src/main/java/com/webforj/samples/views/button/ButtonThemesView.java
@@ -1,9 +1,13 @@
 package com.webforj.samples.views.button;
 
+import com.webforj.bundle.annotation.BundleEntry;
 import com.webforj.component.Composite;
 import com.webforj.component.button.Button;
 import com.webforj.component.button.ButtonTheme;
-import com.webforj.component.html.elements.Div;
+import com.webforj.component.icons.Icon;
+import com.webforj.component.icons.IconButton;
+import com.webforj.component.icons.TablerIcon;
+import com.webforj.component.layout.flexlayout.FlexAlignment;
 import com.webforj.component.layout.flexlayout.FlexDirection;
 import com.webforj.component.layout.flexlayout.FlexLayout;
 import com.webforj.component.layout.flexlayout.FlexWrap;
@@ -11,50 +15,85 @@ import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
 
 @Route
+@BundleEntry("css/button/buttonThemes.css")
 @FrameTitle("Button Themes")
 public class ButtonThemesView extends Composite<FlexLayout> {
   private final FlexLayout self = getBoundComponent();
-  private final Div scrollWrapper = new Div();
+  private final IconButton rightIcon = new IconButton(TablerIcon.create("caret-right"));
+  private final IconButton leftIcon = new IconButton(TablerIcon.create("caret-left"));
+  private final FlexLayout solidRow = new FlexLayout();
+  private final FlexLayout outlinedRow = new FlexLayout();
+  private final FlexLayout buttonWrapper = new FlexLayout(solidRow, outlinedRow);
+  private int counter = 0;
+  private int order;
+  private int targetButton;
 
   public ButtonThemesView() {
-    self.setDirection(FlexDirection.COLUMN)
-        .setSpacing("var(--dwc-space-l)")
-        .setMargin("var(--dwc-space-l)")
-        .add(scrollWrapper);
+    self.setSize("fit-content", "100vh")
+        .setMargin("auto")
+        .setAlignment(FlexAlignment.CENTER)
+        .add(leftIcon, buttonWrapper, rightIcon);
 
-    scrollWrapper
-        .setStyle("overflow-x", "auto")
-        .setStyle("white-space", "nowrap")
-        .setStyle("margin", "var(--dwc-space-l)");
+    solidRow
+        .setDirection(FlexDirection.ROW)
+        .setWrap(FlexWrap.NOWRAP)
+        .setSpacing("var(--dwc-space-s)");
 
-    FlexLayout solidRow =
-        new FlexLayout()
-            .setDirection(FlexDirection.ROW)
-            .setWrap(FlexWrap.NOWRAP)
-            .setSpacing("var(--dwc-space-s)");
+    outlinedRow
+        .setDirection(FlexDirection.ROW)
+        .setWrap(FlexWrap.NOWRAP)
+        .setSpacing("var(--dwc-space-s)");
 
-    FlexLayout outlinedRow =
-        new FlexLayout()
-            .setDirection(FlexDirection.ROW)
-            .setWrap(FlexWrap.NOWRAP)
-            .setSpacing("var(--dwc-space-s)")
-            .setStyle("margin-bottom", "var(--dwc-space-l)");
+    buttonWrapper
+        .setDirection(FlexDirection.COLUMN)
+        .setPadding("var(--dwc-space-s)")
+        .setWrap(FlexWrap.NOWRAP)
+        .addClassName("buttonWrapperWidth");
 
     for (ButtonTheme theme : ButtonTheme.values()) {
       if (theme.name().startsWith("OUTLINE")) {
-        outlinedRow.add(new Button(theme.name(), theme).setMinWidth("200px").setMaxWidth("200px"));
+        Button outlineButton =
+            new Button(theme.name(), theme).setMaxWidth("200px").setMinWidth("200px");
+        outlinedRow.add(outlineButton);
       } else {
-        solidRow.add(new Button(theme.name(), theme).setMinWidth("200px").setMaxWidth("200px"));
+        solidRow.add(new Button(theme.name(), theme).setMaxWidth("200px").setMinWidth("200px"));
       }
     }
 
-    FlexLayout scrollContent =
-        FlexLayout.create(solidRow, outlinedRow)
-            .vertical()
-            .nowrap()
-            .build()
-            .setSpacing("var(--dwc-space-l)");
+    leftIcon.onClick(
+        e -> {
+          if (counter == 0) {
+            counter = 6;
+          } else {
+            counter--;
+          }
+          targetButton = counter;
+          setButtonOrder(targetButton, e.getComponent());
+        });
 
-    scrollWrapper.add(scrollContent);
+    rightIcon.onClick(
+        e -> {
+          if (counter == 6) {
+            counter = 0;
+            targetButton = 6;
+          } else {
+            ++counter;
+            targetButton = counter - 1;
+          }
+          setButtonOrder(targetButton, e.getComponent());
+        });
+  }
+
+  public void setButtonOrder(int targetButton, Icon sourceIcon) {
+    Button outlineButton = (Button) outlinedRow.getComponents().get(targetButton);
+    Button solidButton = (Button) solidRow.getComponents().get(targetButton);
+
+    if (sourceIcon.getName() == "caret-right") {
+      order = outlinedRow.getItemOrder(outlineButton) + 1;
+    } else {
+      order = outlinedRow.getItemOrder(outlineButton) - 1;
+    }
+    outlinedRow.setItemOrder(order, outlineButton);
+    solidRow.setItemOrder(order, solidButton);
   }
 }

--- a/src/main/java/com/webforj/samples/views/button/ButtonThemesView.java
+++ b/src/main/java/com/webforj/samples/views/button/ButtonThemesView.java
@@ -1,99 +1,52 @@
 package com.webforj.samples.views.button;
 
-import com.webforj.bundle.annotation.BundleEntry;
 import com.webforj.component.Composite;
 import com.webforj.component.button.Button;
 import com.webforj.component.button.ButtonTheme;
-import com.webforj.component.icons.Icon;
-import com.webforj.component.icons.IconButton;
-import com.webforj.component.icons.TablerIcon;
+import com.webforj.component.layout.columnslayout.ColumnsLayout;
+import com.webforj.component.layout.columnslayout.ColumnsLayout.Breakpoint;
 import com.webforj.component.layout.flexlayout.FlexAlignment;
 import com.webforj.component.layout.flexlayout.FlexDirection;
 import com.webforj.component.layout.flexlayout.FlexLayout;
-import com.webforj.component.layout.flexlayout.FlexWrap;
 import com.webforj.router.annotation.FrameTitle;
 import com.webforj.router.annotation.Route;
+import java.util.List;
 
 @Route
-@BundleEntry("css/button/buttonThemes.css")
 @FrameTitle("Button Themes")
 public class ButtonThemesView extends Composite<FlexLayout> {
   private final FlexLayout self = getBoundComponent();
-  private final IconButton rightIcon = new IconButton(TablerIcon.create("caret-right"));
-  private final IconButton leftIcon = new IconButton(TablerIcon.create("caret-left"));
-  private final FlexLayout solidRow = new FlexLayout();
-  private final FlexLayout outlinedRow = new FlexLayout();
-  private final FlexLayout buttonWrapper = new FlexLayout(solidRow, outlinedRow);
-  private int counter = 0;
-  private int order;
-  private int targetButton;
+  private final ColumnsLayout solidThemeLayout = new ColumnsLayout();
+  private final ColumnsLayout outlinedThemeLayout = new ColumnsLayout();
+  private final List<Breakpoint> breakpoints =
+      List.of(new Breakpoint(0, 1), new Breakpoint(400, 2), new Breakpoint(600, 3));
 
   public ButtonThemesView() {
-    self.setSize("fit-content", "100vh")
-        .setMargin("auto")
-        .setAlignment(FlexAlignment.CENTER)
-        .add(leftIcon, buttonWrapper, rightIcon);
 
-    solidRow
-        .setDirection(FlexDirection.ROW)
-        .setWrap(FlexWrap.NOWRAP)
-        .setSpacing("var(--dwc-space-s)");
-
-    outlinedRow
-        .setDirection(FlexDirection.ROW)
-        .setWrap(FlexWrap.NOWRAP)
-        .setSpacing("var(--dwc-space-s)");
-
-    buttonWrapper
+    self.setSize("100vw", "100vh")
+        .setPadding("var(--dwc-space-xl)")
         .setDirection(FlexDirection.COLUMN)
-        .setPadding("var(--dwc-space-s)")
-        .setWrap(FlexWrap.NOWRAP)
-        .addClassName("buttonWrapperWidth");
+        .setAlignment(FlexAlignment.CENTER)
+        .setStyle("overflow-y", "scroll")
+        .add(solidThemeLayout, outlinedThemeLayout);
 
-    for (ButtonTheme theme : ButtonTheme.values()) {
-      if (theme.name().startsWith("OUTLINE")) {
-        Button outlineButton =
-            new Button(theme.name(), theme).setMaxWidth("200px").setMinWidth("200px");
-        outlinedRow.add(outlineButton);
-      } else {
-        solidRow.add(new Button(theme.name(), theme).setMaxWidth("200px").setMinWidth("200px"));
-      }
-    }
-
-    leftIcon.onClick(
-        e -> {
-          if (counter == 0) {
-            counter = 6;
-          } else {
-            counter--;
-          }
-          targetButton = counter;
-          setButtonOrder(targetButton, e.getComponent());
-        });
-
-    rightIcon.onClick(
-        e -> {
-          if (counter == 6) {
-            counter = 0;
-            targetButton = 6;
-          } else {
-            ++counter;
-            targetButton = counter - 1;
-          }
-          setButtonOrder(targetButton, e.getComponent());
-        });
+    setLayout(solidThemeLayout);
+    setLayout(outlinedThemeLayout);
+    setButtonThemes();
   }
 
-  public void setButtonOrder(int targetButton, Icon sourceIcon) {
-    Button outlineButton = (Button) outlinedRow.getComponents().get(targetButton);
-    Button solidButton = (Button) solidRow.getComponents().get(targetButton);
-
-    if (sourceIcon.getName() == "caret-right") {
-      order = outlinedRow.getItemOrder(outlineButton) + 1;
-    } else {
-      order = outlinedRow.getItemOrder(outlineButton) - 1;
+  public void setButtonThemes() {
+    for (ButtonTheme theme : ButtonTheme.values()) {
+      Button button = new Button(theme.name(), theme);
+      if (theme.name().startsWith("OUTLINE")) {
+        outlinedThemeLayout.add(button);
+      } else {
+        solidThemeLayout.add(button);
+      }
     }
-    outlinedRow.setItemOrder(order, outlineButton);
-    solidRow.setItemOrder(order, solidButton);
+  }
+
+  public void setLayout(ColumnsLayout layout) {
+    layout.setBreakpoints(breakpoints).setWidth("100%").setMaxWidth(700);
   }
 }


### PR DESCRIPTION
This PR fixes the [Button themes](https://docs.webforj.com/docs/components/button#themes) sample by condensing the displayed buttons into an infinite carousel, but displays all the buttons if the viewing screen is wide enough.