### PR TITLE
chore: Add DemoHeader link and keep tabs from wrapping in ComponentDemo

### DIFF
--- a/docs/docs/advanced/view-transitions.md
+++ b/docs/docs/advanced/view-transitions.md
@@ -18,6 +18,8 @@ path='/webforj/viewtransitionchat'
 files={[
   'src/main/java/com/webforj/samples/views/viewtransitions/ViewTransitionChatView.java',
   'src/main/frontend/css/viewtransitions/chat.css',
+  'src/main/java/com/webforj/samples/views/viewtransitions/components/DemoHeader.java',
+  'src/main/frontend/css/viewtransitions/components/demo-header.css',
 ]}
 height='450px'
 />
@@ -106,6 +108,8 @@ files={[
   'src/main/java/com/webforj/samples/views/viewtransitions/components/BlogCard.java',
   'src/main/java/com/webforj/samples/views/viewtransitions/components/BlogDetail.java',
   'src/main/frontend/css/viewtransitions/morph.css',
+  'src/main/java/com/webforj/samples/views/viewtransitions/components/DemoHeader.java',
+  'src/main/frontend/css/viewtransitions/components/demo-header.css',
 ]}
 height='650px'
 />
@@ -133,6 +137,8 @@ files={[
   'src/main/java/com/webforj/samples/views/viewtransitions/ViewTransitionShuffleView.java',
   'src/main/java/com/webforj/samples/views/viewtransitions/components/ShuffleCard.java',
   'src/main/frontend/css/viewtransitions/shuffle.css',
+  'src/main/java/com/webforj/samples/views/viewtransitions/components/DemoHeader.java',
+  'src/main/frontend/css/viewtransitions/components/demo-header.css',
 ]}
 height='550px'
 />
@@ -192,6 +198,8 @@ path='/webforj/viewtransitionenterexit'
 files={[
   'src/main/java/com/webforj/samples/views/viewtransitions/ViewTransitionEnterExitView.java',
   'src/main/frontend/css/viewtransitions/enterexit.css',
+  'src/main/java/com/webforj/samples/views/viewtransitions/components/DemoHeader.java',
+  'src/main/frontend/css/viewtransitions/components/demo-header.css',
 ]}
 height='400px'
 />

--- a/docs/src/components/DocsTools/ComponentDemo/CodePanel.js
+++ b/docs/src/components/DocsTools/ComponentDemo/CodePanel.js
@@ -15,9 +15,12 @@ const tabStyles = css`
     border-color: var(--ifm-color-primary);
   }
 
-  .tabs__item {
+  li.tabs__item {
     padding: 5px 20px -2px 20px;
     border-radius: 0px;
+    word-wrap: normal;
+    overflow-wrap: normal;
+    white-space: nowrap;
   }
 `;
 


### PR DESCRIPTION
This PR will close Issue #1089 by adding the links to `DemoHeader` and `demo-header.css`.

I also adjusted the list items inside ComponentDemo, because this fix exposed an edge case in ComponentDemo. If the list of files in the tab items needed scrolling, it was wrapping hyphenated file names. My change keeps them in one line, and makes sure to only target the tab labels, not the code content.