### PR TITLE
docs: Blog for the Azul 2026 Java Report

### DIFF
--- a/docs/blog/2026-08-13-azul-2026-report/index.md
+++ b/docs/blog/2026-08-13-azul-2026-report/index.md
@@ -1,0 +1,42 @@
+---
+title: "Azul 2026 State of Java Survey & Report: Where webforJ Fits"
+description: "Using the results from the Azul 2026 Survey, discover how webforJ can help Java developers."
+slug: azul-2026-state-of-java-report
+date: 2026-08-13
+authors: Ben Brennan
+tags: [ai, community, modernization, performance]
+image: "https://cdn.webforj.com/webforj-documentation/blogs/2026-08-13-azul-2026-report/blog-cover.png"
+hide_table_of_contents: true
+---
+
+![cover image](https://cdn.webforj.com/webforj-documentation/blogs/2026-08-13-azul-2026-report/blog-cover.png)
+
+Earlier this year, Azul, a Java-focused company, released its [2026 State of Java Survey & Report](https://www.azul.com/state-of-java-2026/). Based on responses from over 2,000 Java professionals worldwide, Azul revealed that developers are focused on managing cloud computing, securing apps, and controlling AI output.
+
+Java remains a dominant force in development, with 64% of respondents reporting that more than half of their apps or workloads are built with Java or run on a Java Virtual Machine (JVM). For developers who wish to bring their apps to the browser with minimal changes to their architecture, webforJ offers a strategic approach to modernizing apps quickly and efficiently.
+
+<!-- truncate -->
+
+## Handling cloud computing {#handling-cloud-computing}
+
+An increasing demand for browser-based apps and globally accessible data requires more cloud computing. For 43% of the respondents, JVM-based workloads now account for over half of their public cloud compute spend. 97% of organizations in the survey are taking multiple actions to reduce these costs, with the majority opting for a high-performance Java platform.
+
+With webforJ's performance-first, thin-client architecture, it transmits only the necessary event messages and employs a lazy-loading strategy. Only loading the data that needs to be shown drastically increases resource allocation density and reduces processing time. Developers were also interested in having more secure apps.
+
+## Making apps secure {#making-apps-secure}
+
+The majority of enterprise development time is spent addressing security risks. 56% of organizations manage Java-based Common Vulnerabilities and Exposures (CVEs) daily or weekly, while 30% of DevOps time is lost to false-positive investigations. Furthermore, 63% of respondents report that dead or unused code greatly impacts DevOps productivity.
+
+webforJ offers a structural solution by implementing a unified Java architecture. By eliminating the traditional JavaScript/HTML frontend stack, enterprises can effectively "starve" security risks by focusing solely on protecting the JVM. webforJ encapsulates business logic entirely on the server, preventing client-side logic manipulation, a primary driver of the daily CVE cycle. webforJ also communicates between the client and server through obfuscated messages and events, providing a layer of defense against data scraping and unauthorized API probing.
+
+## Controlling AI output {#controlling-AI-output}
+
+We're in the midst of an "AI Explosion" within the Java ecosystem. 62% of survey respondents use Java to implement AI features, reflecting a growing trend of adding AI to existing systems, and 30% of all new Java code is now AI-generated. However, the rush to automate has led to hallucinations because the AI model infers framework conventions, resulting in code that appears syntactically correct but fails at runtime due to a lack of architectural context.
+
+The webforJ Model Context Protocol (MCP) server addresses this by providing a necessary foundation of knowledge. The MCP server plugs AI assistants directly into a "single source of truth," giving access to the live webforJ documentation, APIs, and design tokens. This makes the generated code adhere to verifiable framework rules rather than statistical guesses.
+
+You can read the [MCP Server](/docs/ai-tooling/mcp) docs to find out more about how the webforJ MCP server can help you in your app development.
+
+## Final words {#final-words}
+
+The Azul 2026 Survey has given us insights into the current state of Java development, and webforJ is uniquely positioned to help those developers with their next project. By using a resource-efficient architecture to slash cloud compute costs, centralizing logic on the JVM to eliminate frontend security vulnerabilities, and having access to an MCP server with precise, context-aware info for AI code generation, webforJ empowers developers to build with confidence.


### PR DESCRIPTION
This PR adds a blog talking about the [Azul 2026 State of Java Survey & Report](https://www.azul.com/state-of-java-2026/) and how using the webforJ framework can help address problems that Java developers have.

No cover image yet, but it should be uploaded to CDN server at the following URL:
https://cdn.webforj.com/webforj-documentation/blogs/2026-08-13-azul-2026-report/blog-cover.png