### PR TITLE
docs: Added link to the built-with-webforj repository

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -354,6 +354,10 @@ module.exports = async function createConfig() {
               href: 'https://github.com/webforj/webforj/blob/main/CONTRIBUTING.md',
               rel: null,
             },
+            {
+              label: "Built with webforJ",
+              href: 'https://github.com/webforj/built-with-webforj',
+            },
           ]
         },
         {


### PR DESCRIPTION
This PR will close Issue #1098 by adding a link to the built-with-webforj repository in the  Developers dropdown.